### PR TITLE
Test that exercises a yjs class

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "npm run lint:js",
     "dev": "wrangler dev src/edge.js",
     "deploy": "wrangler deploy src/edge.js",
-    "test": "c8 mocha"
+
+    "test": "c8 mocha --exit # --exit is needed because some test code triggers async listeners"
   },
   "mocha": {
     "reporter": "mocha-multi-reporters",

--- a/src/edge.js
+++ b/src/edge.js
@@ -167,7 +167,7 @@ export const updateHandler = (update, _origin, doc) => {
   doc.conns.forEach((_, conn) => send(doc, conn, message));
 };
 
-class WSSharedDoc extends Y.Doc {
+export class WSSharedDoc extends Y.Doc {
   constructor(name) {
     super({ gc: gcEnabled });
     this.name = name;


### PR DESCRIPTION
Additional test that exercises the `WSSharedDoc` class.

Added `--exit` to the Mocha invocation to let it deal with threads created by the document.