### PR TITLE
Orchestrate initial binding better between multiple clients.

### DIFF
--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -223,9 +223,17 @@ export const getBindPromise = async (docName, doc, conn, existingPromise, fnWait
   if (existingPromise) {
     const hasContent = doc.getMap('aem')?.has('content');
     if (doc.boundState && hasContent) {
+      // eslint-disable-next-line no-param-reassign
+      delete doc.promiseParties;
       return existingPromise;
     } else {
-      return fnWait(500).then(() => existingPromise);
+      if (!doc.promiseParties) {
+        // eslint-disable-next-line no-param-reassign
+        doc.promiseParties = [];
+      }
+      doc.promiseParties.push('true'); // wait extra for each interested party
+      await fnWait(doc.promiseParties.length * 500);
+      return existingPromise;
     }
   } else {
     return persistence.bindState(docName, doc, conn)

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -726,8 +726,8 @@ describe('Collab Test Suite', () => {
           calls.push('bindState');
         };
 
-        const mockWait = async () => {
-          calls.push('wait');
+        const mockWait = async (amount) => {
+          calls.push(`wait ${amount}`);
         };
 
         const docName = 'http://foo.bar/123.4.html';
@@ -748,7 +748,7 @@ describe('Collab Test Suite', () => {
 
         assert.equal(2, calls.length);
         assert(calls.includes('bindState'), 'Should be 1 call to bindState');
-        assert(calls.includes('wait'), 'Should be 1 call to wait');
+        assert(calls.includes('wait 500'), 'Should be 1 call to wait');
 
         assert(mockDoc.boundState);
 
@@ -765,9 +765,9 @@ describe('Collab Test Suite', () => {
         assert.equal(3, calls.length);
 
         // Count the occurrences of items in the array
-        const countMap = calls.reduce((a, e) => a.set(e, (a.get(e) || 0) + 1), new Map());
-        assert.equal(1, countMap.get('bindState'), 'Should still be only 1 call to bindState');
-        assert.equal(2, countMap.get('wait'), 'Should still call wait as the content is not yet on the doc');
+        assert(calls.includes('bindState'), 'Should be 1 call to bindState');
+        assert(calls.includes('wait 500'), 'Should be 1 call to wait with wait 500');
+        assert(calls.includes('wait 1000'), 'Should be 1 call to wait with wait 1000');
 
         // Make a 4th request, now with the content in the doc map
         docMap.set('content', 'some content');


### PR DESCRIPTION
## Description

The first client simply binds to initialise the ydoc. Second and subsequent clients each wait 500ms on the previous, to allow one client to initialize the shared ydoc at one time.

## Motivation and Context

To make the ydoc initialisation process more robust when multiple client (re)connect.

## How Has This Been Tested?

Through a new unit test and additional manual testing.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
