### PR TITLE
Use service binding to access da-admin

### DIFF
--- a/src/edge.js
+++ b/src/edge.js
@@ -56,9 +56,12 @@ async function syncAdmin(url, request, env) {
   return roomObject.fetch(new URL(`${doc}?api=syncAdmin`));
 }
 
-function ping() {
+function ping(env) {
+  const adminsb = env.daadmin !== undefined ? '"da-admin"' : '';
+
   const json = `{
-  "status": "ok"
+  "status": "ok",
+  "service_bindings": [${adminsb}]
 }
 `;
   return new Response(json, { status: 200 });
@@ -67,7 +70,7 @@ function ping() {
 async function handleApiCall(url, request, env) {
   switch (url.pathname) {
     case '/api/v1/ping':
-      return ping();
+      return ping(env);
     case '/api/v1/syncadmin':
       return syncAdmin(url, request, env);
     default:

--- a/src/edge.js
+++ b/src/edge.js
@@ -108,7 +108,18 @@ export async function handleApiRequest(request, env, ffetch = fetch) {
     if (auth) {
       opts.headers = new Headers({ Authorization: auth });
     }
-    const initialReq = await ffetch(docName, opts);
+
+    let initialReq;
+    if (env.daadmin) {
+      // If service binding set, use that to call da-admin
+
+      // eslint-disable-next-line no-console
+      console.log('Using service binding to contact da-admin');
+      initialReq = await env.daadmin.fetch(docName, opts);
+    } else {
+      initialReq = await ffetch(docName, opts);
+    }
+
     if (!initialReq.ok && initialReq.status !== 404) {
       // eslint-disable-next-line no-console
       console.log(`${initialReq.status} - ${initialReq.statusText}`);
@@ -239,6 +250,6 @@ export class DocRoom {
     // eslint-disable-next-line no-console
     console.log(`setupWSConnection ${docName} with auth(${webSocket.auth
       ? webSocket.auth.substring(0, webSocket.auth.indexOf(' ')) : 'none'})`);
-    await setupWSConnection(webSocket, docName);
+    await setupWSConnection(webSocket, docName, this.env);
   }
 }

--- a/test/edge.test.js
+++ b/test/edge.test.js
@@ -355,5 +355,18 @@ describe('Worker test suite', () => {
     assert.equal(200, res.status);
     const json = await res.json();
     assert.equal('ok', json.status);
+    assert.deepStrictEqual([], json.service_bindings);
+  });
+
+  it('Test ping API with service binding', async () => {
+    const req = {
+      url: 'http://some.host.name/api/v1/ping',
+    }
+
+    const res = await defaultEdge.fetch(req, { daadmin: {}});
+    assert.equal(200, res.status);
+    const json = await res.json();
+    assert.equal('ok', json.status);
+    assert.deepStrictEqual(['da-admin'], json.service_bindings);
   });
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,6 +4,10 @@ compatibility_date = "2023-10-30"
 
 main = "src/edge.js"
 
+services = [
+  { binding = "daadmin", service = "da-admin" }
+]
+
 [dev]
 port = 4711
 


### PR DESCRIPTION
## Description

Use the service binding if available, otherwise fall back to access via the internet.

## Related Issue

Fixes #15 

## Motivation and Context

Increases efficiency in communicating with da-admin

## How Has This Been Tested?

Tested locally in the wrangler environment and also added unit tests to cover the functionality.

## Types of changes


- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
