### PR TITLE
Add simple ping API

### DIFF
--- a/src/edge.js
+++ b/src/edge.js
@@ -56,8 +56,18 @@ async function syncAdmin(url, request, env) {
   return roomObject.fetch(new URL(`${doc}?api=syncAdmin`));
 }
 
+function ping() {
+  const json = `{
+  "status": "ok"
+}
+`;
+  return new Response(json, { status: 200 });
+}
+
 async function handleApiCall(url, request, env) {
   switch (url.pathname) {
+    case '/api/v1/ping':
+      return ping();
     case '/api/v1/syncadmin':
       return syncAdmin(url, request, env);
     default:

--- a/test/edge.test.js
+++ b/test/edge.test.js
@@ -318,4 +318,15 @@ describe('Worker test suite', () => {
     const res = await handleApiRequest(req, {}, mockFetch);
     assert.equal(401, res.status);
   });
+
+  it('Test ping API', async () => {
+    const req = {
+      url: 'http://do.re.mi/api/v1/ping',
+    }
+
+    const res = await defaultEdge.fetch(req, {});
+    assert.equal(200, res.status);
+    const json = await res.json();
+    assert.equal('ok', json.status);
+  });
 });


### PR DESCRIPTION
## Description

Add `/api/v1/ping` endpoint for liveness check.

The endpoint responds in JSON:

```
{
  "status": "ok"
}
```

## Related Issue

Fixes #31 

## Motivation and Context

For status reporting on the service. To see if it is still alive.

## How Has This Been Tested?

Tested using CURL.
Also tested via newly added unit test.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
