### PR TITLE
Clear durable object storage if document was deleted.

### DIFF
--- a/test/collab.test.js
+++ b/test/collab.test.js
@@ -157,7 +157,7 @@ assert.equal(result, html);
     assert.equal(result, html);
   });
 
-  it.only('Test regional edit table parsing', async () => {
+  it('Test regional edit table parsing', async () => {
     const html = readFileSync('./test/mocks/regional-edit-1.html', 'utf-8');
     const yDoc = new Y.Doc();
     aem2doc(html, yDoc);


### PR DESCRIPTION
## Description

When a document was deleted from da-admin but it was still present in da-collab durable object storage, this storage needs to be cleared, otherwise, when the user re-creates a document with the same name it will briefly show the old content. It will still be removed after a second, but it should not be visible in the first place.

## How Has This Been Tested?

* Unit tests
* Locally with da-admin and da-live

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
