### PR TITLE
Support for colspan attribute in tables

### DIFF
--- a/src/collab.js
+++ b/src/collab.js
@@ -247,7 +247,16 @@ export function aem2doc(html, ydoc) {
       }
 
       if (prop === 'getAttribute') {
-        return (name) => (target.properties ? target.properties[name] : undefined);
+        return (name) => {
+          if (name === 'colspan') {
+            // when `tree` is created using `fromHtml` in hast-util-from-html
+            // that then calls fromParse5 in hast-util-from-parse5
+            // which converts the `colspan` attribute to `colSpan`
+            // eslint-disable-next-line no-param-reassign
+            name = 'colSpan';
+          }
+          return target.properties ? target.properties[name] : undefined;
+        };
       }
 
       if (prop === 'hasAttribute') {


### PR DESCRIPTION
I do not know why it's converted from `colspan` to `colSpan`.  This adds a special case for this scenario.

`getCellAttrs` in prosemirror-tables looks for the (lower-case) `colspan` attribute.

