### PR TITLE
Add support for custom image links

### DIFF
--- a/src/collab.js
+++ b/src/collab.js
@@ -99,8 +99,18 @@ function getImageNodeWithHref() {
       },
     }],
     toDOM(node) {
-      const { src, alt, title, href } = node.attrs;
-      return ['img', { src, alt, title, href }];
+      const {
+        src,
+        alt,
+        title,
+        href,
+      } = node.attrs;
+      return ['img', {
+        src,
+        alt,
+        title,
+        href,
+      }];
     },
   };
 }

--- a/test/collab.test.js
+++ b/test/collab.test.js
@@ -33,6 +33,27 @@ describe('Parsing test suite', () => {
     assert.equal(result, html);
   })
 
+  it.only('Test linked image', async () => {
+    const html = `
+<body>
+  <header></header>
+  <main><div><a href="https://i.am.link" title="abc"><img src="http://www.foo.com/myimg.jpg"></a></div></main>
+  <footer></footer>
+</body>
+`;
+    const expectedResult = `
+<body>
+  <header></header>
+  <main><div><a href="https://i.am.link"><picture><source srcset="http://www.foo.com/myimg.jpg"><source srcset="http://www.foo.com/myimg.jpg" media="(min-width: 600px)"><img src="http://www.foo.com/myimg.jpg" title="abc"></picture></a></div></main>
+  <footer></footer>
+</body>
+`;
+    const yDoc = new Y.Doc();
+    aem2doc(html, yDoc);
+    const result = doc2aem(yDoc);
+    assert.equal(result, expectedResult);
+  });
+
   it('Test empty roundtrip', async () => {
         const html = `
 <body>

--- a/test/collab.test.js
+++ b/test/collab.test.js
@@ -33,7 +33,7 @@ describe('Parsing test suite', () => {
     assert.equal(result, html);
   })
 
-  it.only('Test linked image', async () => {
+  it('Test linked image', async () => {
     const html = `
 <body>
   <header></header>

--- a/test/collab.test.js
+++ b/test/collab.test.js
@@ -37,14 +37,14 @@ describe('Parsing test suite', () => {
     const html = `
 <body>
   <header></header>
-  <main><div><a href="https://i.am.link" title="abc"><img src="http://www.foo.com/myimg.jpg"></a></div></main>
+  <main><div><img src="http://www.foo.com/myimg.jpg" href="https://i.am.link" title="Img Title"></a></div></main>
   <footer></footer>
 </body>
 `;
     const expectedResult = `
 <body>
   <header></header>
-  <main><div><a href="https://i.am.link"><picture><source srcset="http://www.foo.com/myimg.jpg"><source srcset="http://www.foo.com/myimg.jpg" media="(min-width: 600px)"><img src="http://www.foo.com/myimg.jpg" title="abc"></picture></a></div></main>
+  <main><div><a href="https://i.am.link" title="Img Title"><picture><source srcset="http://www.foo.com/myimg.jpg"><source srcset="http://www.foo.com/myimg.jpg" media="(min-width: 600px)"><img src="http://www.foo.com/myimg.jpg"></picture></a></div></main>
   <footer></footer>
 </body>
 `;


### PR DESCRIPTION
Image links are created by using the `href` attribute on an `img` element.