### PR TITLE
Support handling a table with an empty header cell

### DIFF
--- a/src/collab.js
+++ b/src/collab.js
@@ -399,10 +399,10 @@ function toBlockCSSClassNames(text) {
     .filter((name) => !!name);
 }
 
-function tableToBlock(child, fragment) {
+export function tableToBlock(child, fragment) {
   const rows = child.children[0].children;
   const nameRow = rows.shift();
-  const className = toBlockCSSClassNames(nameRow.children[0].children[0].children[0].text).join(' ');
+  const className = toBlockCSSClassNames(nameRow.children[0].children[0].children[0]?.text).join(' ');
   const block = { type: 'div', attributes: { class: className }, children: [] };
   fragment.children.push(block);
   rows.forEach((row) => {

--- a/test/collab.test.js
+++ b/test/collab.test.js
@@ -12,7 +12,7 @@
 import assert from 'assert';
 import * as Y from 'yjs';
 import { readFileSync } from 'fs';
-import { aem2doc, doc2aem } from '../src/collab.js';
+import { aem2doc, doc2aem, tableToBlock } from '../src/collab.js';
 
 const collapseTagWhitespace = (str) => str.replace(/>\s+</g, '><');
 const collapseWhitespace = (str) => collapseTagWhitespace(str.replace(/\s+/g, ' '));
@@ -249,6 +249,66 @@ assert.equal(result, html);
     console.log(result);
     assert.equal(result, htmlOut,
       'The horizontal line should have been converted to a section break');
+  });
+
+  it('Test table with empty header', () => {
+    const values = {
+      // no values
+    }
+    const p = {
+      children: [values]
+    }
+    const tr = {
+      children: [p]
+    }
+    const td = {
+      children: [tr]
+    }
+    const tbody = {
+      children: [td]
+    }
+    const table = {
+      children: [tbody]
+    }
+
+    const fragment = {
+      children: []
+    }
+    tableToBlock(table, fragment);
+    assert.equal(1, fragment.children.length);
+    const divEl = fragment.children[0];
+    assert.equal('div', divEl.type);
+    assert.equal('', divEl.attributes.class);
+  });
+
+  it('Test table with non-empty header', () => {
+    const values = {
+      text: 'myblock'
+    }
+    const p = {
+      children: [values]
+    }
+    const tr = {
+      children: [p]
+    }
+    const td = {
+      children: [tr]
+    }
+    const tbody = {
+      children: [td]
+    }
+    const table = {
+      children: [tbody]
+    }
+
+    const fragment = {
+      children: []
+    }
+    tableToBlock(table, fragment);
+    assert.equal(1, fragment.children.length);
+    const divEl = fragment.children[0];
+    assert.equal('div', divEl.type);
+    assert.equal('myblock', divEl.attributes.class);
   });
 });
 


### PR DESCRIPTION
## Description

If a table was presented which does not have a value in the header cell or if a table was presented which had multiple header cells and the first one was empty this would cause an exception. This PR fixes that issue.

## Related Issue

Fixes: #49

## How Has This Been Tested?

* Additional unit tests
* Also tested locally with da-live and da-admin

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
