### PR TITLE
Add support for data-id in tables

### DIFF
--- a/test/collab.test.js
+++ b/test/collab.test.js
@@ -18,6 +18,31 @@ const collapseTagWhitespace = (str) => str.replace(/>\s+</g, '><');
 const collapseWhitespace = (str) => collapseTagWhitespace(str.replace(/\s+/g, ' '));
 
 describe('Parsing test suite', () => {
+  it('table data-id support', async () => {
+    let html = `
+      <body>
+        <header></header>
+        <main>
+          <div>
+            <div class="hello" data-id="96789">
+              <div>
+                <div><p>Row 1 - Column 1</p></div>
+                <div><p>Row 1 - Column 2</p></div>
+              </div>
+            </div>
+          </div>
+        </main>
+        <footer></footer>
+      </body>
+      `;
+
+    html = collapseWhitespace(html);
+    const yDoc = new Y.Doc();
+    aem2doc(html, yDoc);
+    const result = doc2aem(yDoc);
+    assert.equal(collapseWhitespace(result), html);
+  });
+
   it('DIV block respects colspan', async () => {
     let html = `
       <body>


### PR DESCRIPTION
In order to track tables for regional edit comparisons, a `data-id` property is being added to tables.  Collab/Prosemirror will strip any unknown properties, so this adds support for the attribute.  The attribute isn't actually added or modified by collab/prosemirror, just retained if it exists.