### PR TITLE
Add timings to the setting up of the web socket

### DIFF
--- a/test/edge.test.js
+++ b/test/edge.test.js
@@ -220,7 +220,10 @@ describe('Worker test suite', () => {
 
     try {
       const bindCalled = [];
-      persistence.bindState = async (nm, d, c) => bindCalled.push({nm, d, c});
+      persistence.bindState = async (nm, d, c) => {
+        bindCalled.push({nm, d, c});
+        return new Map();
+      }
 
       const wspCalled = [];
       const wsp0 = {};

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -781,7 +781,10 @@ describe('Collab Test Suite', () => {
 
     try {
       const bindCalls = [];
-      persistence.bindState = async (nm, d, c, s) => bindCalls.push({nm, d, c, s});
+      persistence.bindState = async (nm, d, c, s) => {
+        bindCalls.push({nm, d, c, s});
+        return new Map();
+      }
 
       const docName = 'https://somewhere.com/somedoc.html';
       const eventListeners = new Map();
@@ -826,7 +829,7 @@ describe('Collab Test Suite', () => {
     const savedBind = persistence.bindState;
 
     try {
-      persistence.bindState = async (nm, d, c, s) => {};
+      persistence.bindState = async (nm, d, c, s) => new Map();
 
       const docName = 'https://somewhere.com/myotherdoc.html';
       const closeCalls = [];


### PR DESCRIPTION
## Description

For responsiveness timing purposes.
The timings are added as response headers to the Web Socket setup process.
They include the following data (in milliseconds) ordered by when it happens:
* X-1-timing-da-admin-head-duration: Duration of the initial HEAD call on da-admin
* X-2-timing-docroom-get-duration: Duration of the time it takes to get the room object
* X-4-timing-da-admin-get-duration: Duration of the time it takes to do a GET call on da-admin
* X-5-timing-read-state-duration: Duration of time time it takes to read the document state from durable object persistent storage
* X-7-timing-setup-websocket-duration: Accumulated time it takes to set up the websocket. Includes X-4 and X-5
* X-9-timing-full-duration: The total duration. Includes all of the above.

## Motivation and Context

To investigate where time is spent on occasional slow initial setups.

## How Has This Been Tested?

Using the chrome response inspector.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
