### PR TITLE
fix: remove html comments

### DIFF
--- a/src/collab.js
+++ b/src/collab.js
@@ -132,10 +132,19 @@ function fixImageLinks(node) {
   return node;
 }
 
+function removeComments(node) {
+  if (!node) return node;
+  // eslint-disable-next-line no-param-reassign
+  node.children = node.children?.filter((child) => child.type !== 'comment') || [];
+  node.children.forEach(removeComments);
+  return node;
+}
+
 export function aem2doc(html, ydoc) {
   const tree = fromHtml(html, { fragment: true });
   const main = tree.children.find((child) => child.tagName === 'main');
   fixImageLinks(main);
+  removeComments(main);
   (main.children || []).forEach((parent) => {
     if (parent.tagName === 'div' && parent.children) {
       const children = [];

--- a/test/collab.test.js
+++ b/test/collab.test.js
@@ -85,6 +85,27 @@ describe('Parsing test suite', () => {
     assert.equal(result, html);
   })
 
+  it('Comments are not an issue', async () => {
+    const html = `
+<body>
+  <header></header>
+  <!-- Comment before main --><main><!-- Comment before div --><div><!-- Comment before h1 --><h1>test title</h1><!-- Comment after h1 --></div><!-- Comment after div --></main><!-- Comment after main -->
+  <footer></footer>
+</body>
+`;
+    const expectedResult = `
+<body>
+  <header></header>
+  <main><div><h1>test title</h1></div></main>
+  <footer></footer>
+</body>
+`;
+    const yDoc = new Y.Doc();
+    aem2doc(html, yDoc);
+    const result = doc2aem(yDoc);
+    assert.equal(result, expectedResult);
+  });
+
   it('Test linked image', async () => {
     const html = `
 <body>


### PR DESCRIPTION
Fix https://github.com/adobe/da-live/issues/414

It seems that `prosemirror-model` can parse the html comments. I think the issue is introduced by the custom schema. But... the parsing would move the html comments inside a `p` tag. I do not think this what we want... for now, I suggest to remove the comments, they will disappear from the document.