### PR TITLE
Use document GUID as prosemirror reference to avoid updating deleted documents

### DIFF
--- a/src/edge.js
+++ b/src/edge.js
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { invalidateFromAdmin, setupWSConnection } from './shareddoc.js';
+import { deleteFromAdmin, invalidateFromAdmin, setupWSConnection } from './shareddoc.js';
 
 // This is the Edge Worker, built using Durable Objects!
 
@@ -217,7 +217,7 @@ export class DocRoom {
     const api = url.searchParams.get('api');
     switch (api) {
       case 'deleteAdmin':
-        if (await invalidateFromAdmin(baseURL)) {
+        if (await deleteFromAdmin(baseURL)) {
           return new Response(null, { status: 204 });
         } else {
           return new Response('Not Found', { status: 404 });

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -271,7 +271,7 @@ export const persistence = {
         return current;
       }
 
-      const content = doc2aem(ydoc, guid);
+      const content = doc2aem(ydoc, curGuid);
       if (current !== content) {
         // Only store the document if it was actually changed.
 

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -265,6 +265,8 @@ export const persistence = {
 
       if (!newDoc && !guid) {
         // Someone is still editing a document in the browser that has since been deleted
+        // we know it's deleted because guid from da-admin is not set.
+        // eslint-disable-next-line no-console
         console.log('Document GUID mismatch, da-admin guid:', guid, 'edited guid:', curGuid);
         showError(ydoc, { message: 'This document has since been deleted, your edits are not persisted' });
         return current;
@@ -378,8 +380,11 @@ export const persistence = {
     if (!restored && guid) {
       // The doc was not restored from worker persistence, so read it from da-admin,
       // but only if the doc actually exists in da-admin (guid has a value).
-      // but do this async to give the ydoc some time to get synced up first. Without
-      // this timeout, the ydoc can get confused which may result in duplicated content.
+      // If it's a brand new document, subsequent update() calls will set it in
+      // da-admin and provide the guid to use.
+
+      // Do this async to give the ydoc some time to get synced up first. Without this
+      // timeout, the ydoc can get confused which may result in duplicated content.
       setTimeout(() => {
         if (ydoc === docs.get(docName)) {
           const rootType = ydoc.getXmlFragment(`prosemirror-${guid}`);

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -254,7 +254,6 @@ export const persistence = {
       // when the document is just opened in the browser.
       const guidArray = ydoc.getArray('prosemirror-guids');
       const copy = [...guidArray];
-      console.log('guidArray', copy);
       if (copy.length === 0) {
         // eslint-disable-next-line no-console
         console.log('No guid array found in update. Ignoring.');

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -193,6 +193,8 @@ export const persistence = {
    * @param {WSSharedDoc} ydoc - The Yjs document, which among other things contains the service
    * binding to da-admin.
    * @param {string} content - The content to store
+   * @param {string} guid - The guid of the document to store. It must match what da-admin has
+   * or if this is a new document, da-admin will use this guid.
    * @returns {object} The response from da-admin.
    */
   put: async (ydoc, content, guid) => {
@@ -221,9 +223,7 @@ export const persistence = {
       });
     }
 
-    const {
-      ok, status, statusText,
-    } = await ydoc.daadmin.fetch(ydoc.name, opts);
+    const { ok, status, statusText } = await ydoc.daadmin.fetch(ydoc.name, opts);
 
     return {
       ok,
@@ -274,9 +274,7 @@ export const persistence = {
       if (current !== content) {
         // Only store the document if it was actually changed.
 
-        const {
-          ok, status, statusText,
-        } = await persistence.put(ydoc, content, curGuid);
+        const { ok, status, statusText } = await persistence.put(ydoc, content, curGuid);
         if (newDoc) {
           // Update the guid in the guidHolder so that in subsequent calls we know what it is
           // eslint-disable-next-line no-param-reassign

--- a/test/collab.test.js
+++ b/test/collab.test.js
@@ -38,8 +38,8 @@ describe('Parsing test suite', () => {
 
     html = collapseWhitespace(html);
     const yDoc = new Y.Doc();
-    aem2doc(html, yDoc);
-    const result = doc2aem(yDoc);
+    aem2doc(html, yDoc, 'test-guid');
+    const result = doc2aem(yDoc, 'test-guid');
     assert.equal(collapseWhitespace(result), html);
   });
 
@@ -64,8 +64,8 @@ describe('Parsing test suite', () => {
     html = collapseWhitespace(html);
 
     const yDoc = new Y.Doc();
-    aem2doc(html, yDoc);
-    const result = doc2aem(yDoc);
+    aem2doc(html, yDoc, 'some-guid');
+    const result = doc2aem(yDoc, 'some-guid');
     assert.equal(collapseWhitespace(result), html);
   });
 
@@ -79,8 +79,8 @@ describe('Parsing test suite', () => {
 </body>
 `;
     const yDoc = new Y.Doc();
-    aem2doc(html, yDoc);
-    const result = doc2aem(yDoc);
+    aem2doc(html, yDoc, 'some-guid');
+    const result = doc2aem(yDoc, 'some-guid');
     console.log(result);
     assert.equal(result, html);
   })
@@ -101,8 +101,8 @@ describe('Parsing test suite', () => {
 </body>
 `;
     const yDoc = new Y.Doc();
-    aem2doc(html, yDoc);
-    const result = doc2aem(yDoc);
+    aem2doc(html, yDoc, 'some-guid');
+    const result = doc2aem(yDoc, 'some-guid');
     assert.equal(result, expectedResult);
   });
 
@@ -115,8 +115,8 @@ describe('Parsing test suite', () => {
 </body>
 `;
       const yDoc = new Y.Doc();
-      aem2doc(html, yDoc);
-      const result = doc2aem(yDoc);
+      aem2doc(html, yDoc, 'some-guid');
+      const result = doc2aem(yDoc, 'some-guid');
       assert.equal(result, html);
     });
 
@@ -129,8 +129,8 @@ describe('Parsing test suite', () => {
 </body>
 `;
       const yDoc = new Y.Doc();
-      aem2doc(html, yDoc);
-      const result = doc2aem(yDoc);
+      aem2doc(html, yDoc, 'my-guid');
+      const result = doc2aem(yDoc, 'my-guid');
       assert.equal(result, html);
     });
 
@@ -143,8 +143,8 @@ describe('Parsing test suite', () => {
 </body>
 `;
       const yDoc = new Y.Doc();
-      aem2doc(html, yDoc);
-      const result = doc2aem(yDoc);
+      aem2doc(html, yDoc, 'my-guid');
+      const result = doc2aem(yDoc, 'my-guid');
       assert.equal(result, html);
     });
 
@@ -157,12 +157,12 @@ describe('Parsing test suite', () => {
 </body>
 `;
     const yDoc = new Y.Doc();
-    aem2doc(html, yDoc);
-    const result = doc2aem(yDoc);
+    aem2doc(html, yDoc, 'my-guid');
+    const result = doc2aem(yDoc, 'my-guid');
     assert.equal(result, html);
   });
 
-  it('Test nested marks roundtrip', async () => {
+it('Test nested marks roundtrip', async () => {
     const html = `
 <body>
   <header></header>
@@ -171,10 +171,11 @@ describe('Parsing test suite', () => {
 </body>
 `;
   const yDoc = new Y.Doc();
-  aem2doc(html, yDoc);
-  const result = doc2aem(yDoc);
+  aem2doc(html, yDoc, 'my-guid');
+  const result = doc2aem(yDoc, 'my-guid');
   assert.equal(result, html);
 });
+
 it('Test simple block roundtrip', async () => {
   const html = `
 <body>
@@ -184,8 +185,8 @@ it('Test simple block roundtrip', async () => {
 </body>
 `;
 const yDoc = new Y.Doc();
-aem2doc(html, yDoc);
-const result = doc2aem(yDoc);
+aem2doc(html, yDoc, 'my-guid');
+const result = doc2aem(yDoc, 'my-guid');
 assert.equal(result, html);
 });
 it('Test complex block roundtrip', async () => {
@@ -197,8 +198,8 @@ it('Test complex block roundtrip', async () => {
 </body>
 `;
 const yDoc = new Y.Doc();
-aem2doc(html, yDoc);
-const result = doc2aem(yDoc);
+aem2doc(html, yDoc, 'my-guid');
+const result = doc2aem(yDoc, 'my-guid');
 console.log(result);
 assert.equal(result, html);
 });
@@ -211,8 +212,8 @@ it('Test linebreak roundtrip', async () => {
 </body>
 `;
 const yDoc = new Y.Doc();
-aem2doc(html, yDoc);
-const result = doc2aem(yDoc);
+aem2doc(html, yDoc, 'my-guid');
+const result = doc2aem(yDoc, 'my-guid');
 console.log(result);
 assert.equal(result, html);
 });
@@ -226,8 +227,8 @@ assert.equal(result, html);
 </body>
 `;
     const yDoc = new Y.Doc();
-    aem2doc(html, yDoc);
-    const result = doc2aem(yDoc);
+    aem2doc(html, yDoc, 'my-guid');
+    const result = doc2aem(yDoc, 'my-guid');
     console.log(result);
     assert.equal(result, html);
   });
@@ -235,8 +236,8 @@ assert.equal(result, html);
   it('Test regional edit table parsing', async () => {
     const html = readFileSync('./test/mocks/regional-edit-1.html', 'utf-8');
     const yDoc = new Y.Doc();
-    aem2doc(html, yDoc);
-    const result = doc2aem(yDoc);
+    aem2doc(html, yDoc, 'my-guid');
+    const result = doc2aem(yDoc, 'my-guid');
     assert.equal(collapseWhitespace(result.trim()), collapseWhitespace(html.trim()));
   });
 
@@ -306,8 +307,8 @@ assert.equal(result, html);
       `;
     html = collapseWhitespace(html);
     const yDoc = new Y.Doc();
-    aem2doc(html, yDoc);
-    const result = collapseWhitespace(doc2aem(yDoc));
+    aem2doc(html, yDoc, 'my-guid');
+    const result = collapseWhitespace(doc2aem(yDoc, 'my-guid'));
     assert.equal(result, html);
   });
 
@@ -320,8 +321,8 @@ assert.equal(result, html);
 </body>
 `;
     const yDoc = new Y.Doc();
-    aem2doc(html, yDoc);
-    const result = doc2aem(yDoc);
+    aem2doc(html, yDoc, 'my-guid');
+    const result = doc2aem(yDoc, 'my-guid');
     console.log(result);
     assert.equal(result, html);
   });
@@ -342,8 +343,8 @@ assert.equal(result, html);
 </body>
 `;
     const yDoc = new Y.Doc();
-    aem2doc(htmlIn, yDoc);
-    const result = doc2aem(yDoc);
+    aem2doc(htmlIn, yDoc, 'my-guid');
+    const result = doc2aem(yDoc, 'my-guid');
     console.log(result);
     assert.equal(result, htmlOut,
       'The horizontal line should have been converted to a section break');
@@ -440,8 +441,8 @@ assert.equal(result, html);
 
     html = collapseWhitespace(html);
     const yDoc = new Y.Doc();
-    aem2doc(html, yDoc);
-    const result = doc2aem(yDoc);
+    aem2doc(html, yDoc, 'my-guid');
+    const result = doc2aem(yDoc, 'my-guid');
     assert.equal(collapseWhitespace(result), html);
   });
 
@@ -466,8 +467,8 @@ assert.equal(result, html);
 
     html = collapseWhitespace(html);
     const yDoc = new Y.Doc();
-    aem2doc(html, yDoc);
-    const result = doc2aem(yDoc);
+    aem2doc(html, yDoc, 'my-guid');
+    const result = doc2aem(yDoc, 'my-guid');
     assert.equal(collapseWhitespace(result), html);
   });
 
@@ -497,8 +498,8 @@ assert.equal(result, html);
 
     html = collapseWhitespace(html);
     const yDoc = new Y.Doc();
-    aem2doc(html, yDoc);
-    const result = doc2aem(yDoc);
+    aem2doc(html, yDoc, 'my-guid');
+    const result = doc2aem(yDoc, 'my-guid');
     assert.equal(collapseWhitespace(result), html);
   });
 
@@ -521,8 +522,8 @@ assert.equal(result, html);
   <footer></footer>
 </body>`;
     const yDoc = new Y.Doc();
-    aem2doc(html, yDoc);
-    const result = doc2aem(yDoc);
+    aem2doc(html, yDoc, 'my-guid');
+    const result = doc2aem(yDoc, 'my-guid');
     assert.equal(collapseWhitespace(result), collapseWhitespace(html));
   });
 
@@ -553,8 +554,8 @@ assert.equal(result, html);
   <footer></footer>
 </body>`;
     const yDoc = new Y.Doc();
-    aem2doc(html, yDoc);
-    const result = doc2aem(yDoc);
+    aem2doc(html, yDoc, 'my-guid');
+    const result = doc2aem(yDoc, 'my-guid');
     assert.equal(collapseWhitespace(result), collapseWhitespace(html));
   });
 });

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -744,7 +744,6 @@ describe('Collab Test Suite', () => {
     }
   });
 
-  /* Not sure what use-case this is for... TODO find out!
   it('test bind to empty doc that was stored before updates ydoc', async () => {
     const docName = 'https://admin.da.live/source/foo.html';
 
@@ -783,12 +782,10 @@ describe('Collab Test Suite', () => {
 
       await persistence.bindState(docName, ydoc, conn, storage);
       assert.deepStrictEqual([true], deleteAllCalled);
-      assert.equal(1, setTimeoutCalled.length, 'SetTimeout should have been called to update the doc');
     } finally {
       globalThis.setTimeout = savedSetTimeout;
     }
   });
-  */
 
   it('test persist state in worker storage on update', async () => {
     const docName = 'https://admin.da.live/source/foo/bar.html';

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -744,7 +744,7 @@ describe('Collab Test Suite', () => {
     }
   });
 
-  /* Not sure what use-case this is for...
+  /* Not sure what use-case this is for... TODO find out!
   it('test bind to empty doc that was stored before updates ydoc', async () => {
     const docName = 'https://admin.da.live/source/foo.html';
 


### PR DESCRIPTION
## Description

Previously the prosemirror document would be stored in the `prosemirror` attribute on the YDoc. This changes that to be `prosemirror-${guid}`.
This is to avoid accidentally left open editors from accidentally re-creating a deleted document.

This PR requires https://github.com/adobe/da-admin/pull/135

## Related Issue

https://github.com/adobe/da-live/issues/378

## How Has This Been Tested?

* Locally with da-live and da-admin
* More unit tests added

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
