### PR TITLE
fix: encode HTML brackets

### DIFF
--- a/src/collab.js
+++ b/src/collab.js
@@ -17,6 +17,10 @@ import { fromHtml } from 'hast-util-from-html';
 import { matches } from 'hast-util-select';
 import { getSchema } from './schema.js';
 
+function escapeBrackets(text) {
+  return text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
 function convertSectionBreak(node) {
   if (!node) return;
   if (node.children) {
@@ -278,7 +282,7 @@ function tohtml(node) {
   let attrString = getAttrString(attributes);
   if (!node.children || node.children.length === 0) {
     if (node.type === 'text') {
-      return node.text;
+      return escapeBrackets(node.text);
     }
     if (node.type === 'p') return '';
     if (node.type === 'img' && !attributes.loading) {

--- a/test/collab.test.js
+++ b/test/collab.test.js
@@ -578,6 +578,26 @@ assert.equal(result, html);
     const result = doc2aem(yDoc);
     assert.equal(collapseWhitespace(result), collapseWhitespace(html));
   });
+
+  it('Escapes brackets as needed in text', () => {
+    const htmlIn = `
+<body>
+  <header></header>
+  <main><div><p>AAAA</p><p>&lt;hihi&gt;hoho&lt;/hihi&gt;</p><p>ZZ &amp; ZZ</p></div></main>
+  <footer></footer>
+</body>
+`;
+
+    const yDoc = new Y.Doc();
+    aem2doc(htmlIn, yDoc);
+
+    assert.equal(yDoc.getXmlFragment('prosemirror').toString(),
+      '<paragraph>AAAA</paragraph><paragraph><hihi>hoho</hihi></paragraph><paragraph>ZZ & ZZ</paragraph>',
+      'The text should have been un-escaped');
+
+    const result = doc2aem(yDoc);
+    console.log(result);
+    assert.equal(result, htmlIn,
+      'The escaping of brackets in text should have been applied');
+  });
 });
-
-

--- a/test/collab.test.js
+++ b/test/collab.test.js
@@ -583,7 +583,7 @@ assert.equal(result, html);
     const htmlIn = `
 <body>
   <header></header>
-  <main><div><p>AAAA</p><p>&lt;hihi&gt;hoho&lt;/hihi&gt;</p><p>ZZ &amp; ZZ</p></div></main>
+  <main><div><p>AAAA</p><p>&lt;hihi&gt;hoho&lt;/hihi&gt;aha&lt;p&gt;yes&lt;/p&gt;</p><p>ZZ &amp; ZZ</p></div></main>
   <footer></footer>
 </body>
 `;
@@ -592,7 +592,7 @@ assert.equal(result, html);
     aem2doc(htmlIn, yDoc);
 
     assert.equal(yDoc.getXmlFragment('prosemirror').toString(),
-      '<paragraph>AAAA</paragraph><paragraph><hihi>hoho</hihi></paragraph><paragraph>ZZ & ZZ</paragraph>',
+      '<paragraph>AAAA</paragraph><paragraph><hihi>hoho</hihi>aha<p>yes</p></paragraph><paragraph>ZZ & ZZ</paragraph>',
       'The text should have been un-escaped');
 
     const result = doc2aem(yDoc);


### PR DESCRIPTION
## Description

If the following characters appear in the document text, they are now encoded before sending them to da-admin: `< > &`

I did not encode the `' "` characters as there is no need for it and it would add escape syntax to a lot of documents without the need for it.

No need to add decoding explicitly as that's already handled by the existing code. I did add a unit test to check this though.

## Related Issue

Fixes: #73

## How Has This Been Tested?

* New unit test
* Locally with da-live and da-admin

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
