### PR TITLE
Revert "fix: encode HTML brackets"

### DIFF
--- a/src/collab.js
+++ b/src/collab.js
@@ -17,10 +17,6 @@ import { fromHtml } from 'hast-util-from-html';
 import { matches } from 'hast-util-select';
 import { getSchema } from './schema.js';
 
-function escapeBrackets(text) {
-  return text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
-}
-
 function convertSectionBreak(node) {
   if (!node) return;
   if (node.children) {
@@ -286,7 +282,7 @@ function tohtml(node) {
   let attrString = getAttrString(attributes);
   if (!node.children || node.children.length === 0) {
     if (node.type === 'text') {
-      return escapeBrackets(node.text);
+      return node.text;
     }
     if (node.type === 'p') return '';
     if (node.type === 'img' && !attributes.loading) {

--- a/test/collab.test.js
+++ b/test/collab.test.js
@@ -578,26 +578,6 @@ assert.equal(result, html);
     const result = doc2aem(yDoc);
     assert.equal(collapseWhitespace(result), collapseWhitespace(html));
   });
-
-  it('Escapes brackets as needed in text', () => {
-    const htmlIn = `
-<body>
-  <header></header>
-  <main><div><p>AAAA</p><p>&lt;hihi&gt;hoho&lt;/hihi&gt;aha&lt;p&gt;yes&lt;/p&gt;</p><p>ZZ &amp; ZZ</p></div></main>
-  <footer></footer>
-</body>
-`;
-
-    const yDoc = new Y.Doc();
-    aem2doc(htmlIn, yDoc);
-
-    assert.equal(yDoc.getXmlFragment('prosemirror').toString(),
-      '<paragraph>AAAA</paragraph><paragraph><hihi>hoho</hihi>aha<p>yes</p></paragraph><paragraph>ZZ & ZZ</paragraph>',
-      'The text should have been un-escaped');
-
-    const result = doc2aem(yDoc);
-    console.log(result);
-    assert.equal(result, htmlIn,
-      'The escaping of brackets in text should have been applied');
-  });
 });
+
+


### PR DESCRIPTION
Reverts adobe/da-collab#74

I want to test this a little more before we release this into the wild. I want to also test a hunch I have about encoding on content.da.live. Collab may not be the right place to solve this.