### PR TITLE
feat: move docs map to docroom

### DIFF
--- a/src/edge.js
+++ b/src/edge.js
@@ -9,7 +9,12 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { invalidateFromAdmin, setupWSConnection, createYDoc } from './shareddoc.js';
+import {
+  invalidateFromAdmin,
+  setupWSConnection,
+  createYDoc,
+  setupYDoc,
+} from './shareddoc.js';
 
 // This is the Edge Worker, built using Durable Objects!
 
@@ -329,18 +334,18 @@ export class DocRoom {
 
     let ydoc = this.docs.get(docName);
     if (!ydoc) {
-      // get doc, initialize if it does not exist yet
-      ydoc = await createYDoc(
+      ydoc = createYDoc(
         docName,
         webSocket,
         this.env,
         this.storage,
-        timingData,
         this.docs,
         true,
       );
       this.docs.set(docName, ydoc);
     }
+
+    await setupYDoc(ydoc, webSocket, timingData);
 
     webSocket.addEventListener('close', () => {
       const doc = this.docs.get(docName);

--- a/src/edge.js
+++ b/src/edge.js
@@ -343,9 +343,12 @@ export class DocRoom {
     }
 
     webSocket.addEventListener('close', () => {
-      // eslint-disable-next-line no-console
-      console.log(`Closing connection for ${docName} - removing from docs cache`);
-      this.docs.delete(docName);
+      const doc = this.docs.get(docName);
+      if (doc && doc.conns.size === 0) {
+        // eslint-disable-next-line no-console
+        console.log(`All connections closed for ${docName} - removing from docs cache`);
+        this.docs.delete(docName);
+      }
     });
 
     await setupWSConnection(webSocket, ydoc);

--- a/src/edge.js
+++ b/src/edge.js
@@ -363,6 +363,8 @@ export class DocRoom {
 
     let ydoc = this.docs.get(docName);
     if (!ydoc) {
+      // eslint-disable-next-line no-console
+      console.log('Document not found in cache', docName);
       ydoc = createYDoc(
         docName,
         webSocket,
@@ -372,18 +374,12 @@ export class DocRoom {
         true,
       );
       this.docs.set(docName, ydoc);
+    } else {
+      // eslint-disable-next-line no-console
+      console.log('Document found in cache', docName);
     }
 
     await setupYDoc(ydoc, webSocket, timingData);
-
-    webSocket.addEventListener('close', () => {
-      const doc = this.docs.get(docName);
-      if (doc && doc.conns.size === 0) {
-        // eslint-disable-next-line no-console
-        console.log(`All connections closed for ${docName} - removing from docs cache`);
-        this.docs.delete(docName);
-      }
-    });
 
     await setupWSConnection(webSocket, ydoc);
 

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -163,7 +163,7 @@ export const showError = (ydoc, err) => {
 };
 
 export const persistence = {
-  closeConn: closeConn.bind(this),
+  closeConn,
 
   /**
    * Get the document from da-admin. If da-admin doesn't have the doc, a new empty doc is

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -43,6 +43,13 @@ export const closeConn = (doc, conn) => {
     doc.conns.delete(conn);
     awarenessProtocol.removeAwarenessStates(doc.awareness, Array.from(controlledIds), null);
   }
+
+  if (doc.onClose && doc.conns.size === 0) {
+    // eslint-disable-next-line no-console
+    console.log(`All connections closed for ${doc.name} - removing from docs cache`);
+    doc.onClose();
+  }
+
   conn.close();
 };
 
@@ -446,6 +453,11 @@ export const createYDoc = (docname, conn, env, storage, docsCache, gc = true) =>
   // Store the service binding to da-admin which we receive through the environment in the doc
   doc.daadmin = env.daadmin;
   doc.promise = persistence.bindState(docname, doc, conn, storage, docsCache);
+  doc.onClose = () => {
+    // eslint-disable-next-line no-console
+    console.log('Document on close - remove from docs cache', docname);
+    docsCache.delete(docname);
+  };
 
   return doc;
 };

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -36,21 +36,26 @@ const MAX_STORAGE_VALUE_SIZE = 131072;
  * @param {WebSocket} conn - the websocket connection to close.
  */
 export const closeConn = (doc, conn) => {
-  // eslint-disable-next-line no-console
-  console.log('Closing connection', doc.name, doc.conns.size);
-  if (doc.conns.has(conn)) {
-    const controlledIds = doc.conns.get(conn);
-    doc.conns.delete(conn);
-    awarenessProtocol.removeAwarenessStates(doc.awareness, Array.from(controlledIds), null);
-  }
-
-  if (doc.onClose && doc.conns.size === 0) {
+  try {
     // eslint-disable-next-line no-console
-    console.log(`All connections closed for ${doc.name} - removing from docs cache`);
-    doc.onClose();
-  }
+    console.log('Closing connection', doc.name, doc.conns.size);
+    if (doc.conns.has(conn)) {
+      const controlledIds = doc.conns.get(conn);
+      doc.conns.delete(conn);
+      awarenessProtocol.removeAwarenessStates(doc.awareness, Array.from(controlledIds), null);
+    }
 
-  conn.close();
+    if (doc.onClose && doc.conns.size === 0) {
+      // eslint-disable-next-line no-console
+      console.log(`All connections closed for ${doc.name} - removing from docs cache`);
+      doc.onClose();
+    }
+
+    conn.close();
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('Could not properly close the connection', e);
+  }
 };
 
 const send = (doc, conn, m) => {

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -327,7 +327,6 @@ export const persistence = {
       // this timeout, the ydoc can get confused which may result in duplicated content.
       // eslint-disable-next-line no-console
       console.log('Could not be restored, trying to restore from da-admin', docName);
-      // await new Promise((resolve) => {
       setTimeout(() => {
         if (ydoc === docsCache.get(docName)) {
           const rootType = ydoc.getXmlFragment('prosemirror');

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -431,17 +431,21 @@ export class WSSharedDoc extends Y.Doc {
  * @param {boolean} gc - whether garbage collection is enabled
  * @returns The Yjs document object, which may be shared across multiple sockets.
  */
-export const createYDoc = async (docname, conn, env, storage, timingData, docsCache, gc = true) => {
+export const createYDoc = (docname, conn, env, storage, docsCache, gc = true) => {
   const doc = new WSSharedDoc(docname);
   doc.gc = gc;
-
-  if (!doc.conns.get(conn)) {
-    doc.conns.set(conn, new Set());
-  }
 
   // Store the service binding to da-admin which we receive through the environment in the doc
   doc.daadmin = env.daadmin;
   doc.promise = persistence.bindState(docname, doc, conn, storage, docsCache);
+
+  return doc;
+};
+
+export const setupYDoc = async (doc, conn, timingData) => {
+  if (!doc.conns.get(conn)) {
+    doc.conns.set(conn, new Set());
+  }
 
   // We wait for the promise, for second and subsequent connections to the same doc, this will
   // already be resolved.
@@ -449,7 +453,6 @@ export const createYDoc = async (docname, conn, env, storage, timingData, docsCa
   if (timingData) {
     timings.forEach((v, k) => timingData.set(k, v));
   }
-  return doc;
 };
 
 // This read sync message handles readonly connections

--- a/test/edge.test.js
+++ b/test/edge.test.js
@@ -255,7 +255,7 @@ describe('Worker test suite', () => {
 
       assert(acceptIdx === 0);
       assert(alMessCount === 1);
-      assert(alClsCount === 2);
+      assert(alClsCount === 1);
       assert(clsIdx === wspCalled.length - 1);
     } finally {
       DocRoom.newWebSocketPair = savedNWSP;

--- a/test/edge.test.js
+++ b/test/edge.test.js
@@ -13,7 +13,7 @@ import assert from 'assert';
 
 import * as Y from 'yjs';
 import defaultEdge, { DocRoom, handleApiRequest, handleErrors } from '../src/edge.js';
-import { WSSharedDoc, persistence, setYDoc } from '../src/shareddoc.js';
+import { WSSharedDoc, persistence } from '../src/shareddoc.js';
 import { doc2aem } from '../src/collab.js';
 
 function hash(str) {
@@ -138,7 +138,6 @@ describe('Worker test suite', () => {
   it('Docroom deleteFromAdmin', async () => {
     const ydocName = 'http://foobar.com/q.html';
     const testYdoc = new WSSharedDoc(ydocName);
-    const m = setYDoc(ydocName, testYdoc);
 
     const connCalled = []
     const mockConn = {
@@ -150,12 +149,10 @@ describe('Worker test suite', () => {
       url: `${ydocName}?api=deleteAdmin`
     };
 
-    const dr = new DocRoom({});
+    const dr = new DocRoom({}, {}, new Map([[ydocName, testYdoc]]));
 
-    assert(m.has(ydocName), 'Precondition');
     const resp = await dr.fetch(req)
     assert.equal(204, resp.status);
-    assert(!m.has(ydocName), 'Doc should have been removed');
     assert.deepStrictEqual(['close'], connCalled);
   });
 
@@ -172,8 +169,7 @@ describe('Worker test suite', () => {
   it('Docroom syncFromAdmin', async () => {
     const ydocName = 'http://foobar.com/a/b/c.html';
     const testYdoc = new WSSharedDoc(ydocName);
-    const m = setYDoc(ydocName, testYdoc);
-
+    
     const connCalled = []
     const mockConn = {
       close() { connCalled.push('close'); }
@@ -184,12 +180,10 @@ describe('Worker test suite', () => {
       url: `${ydocName}?api=syncAdmin`
     };
 
-    const dr = new DocRoom({});
+    const dr = new DocRoom({}, {}, new Map([[ydocName, testYdoc]]));
 
-    assert(m.has(ydocName), 'Precondition');
     const resp = await dr.fetch(req)
     assert.equal(200, resp.status);
-    assert(!m.has(ydocName), 'Doc should have been removed');
     assert.deepStrictEqual(['close'], connCalled);
   });
 
@@ -255,14 +249,14 @@ describe('Worker test suite', () => {
       assert.equal('au123', wsp1.auth);
 
       const acceptIdx = wspCalled.indexOf('accept');
-      const alMessIdx = wspCalled.indexOf('addEventListener message');
-      const alClsIdx = wspCalled.indexOf('addEventListener close');
+      const alMessCount = wspCalled.filter(call => call === 'addEventListener message').length;
+      const alClsCount = wspCalled.filter(call => call === 'addEventListener close').length;
       const clsIdx = wspCalled.indexOf('close');
 
-      assert(acceptIdx >= 0);
-      assert(alMessIdx > acceptIdx);
-      assert(alClsIdx > alMessIdx);
-      assert(clsIdx > alClsIdx);
+      assert(acceptIdx === 0);
+      assert(alMessCount === 1);
+      assert(alClsCount === 2);
+      assert(clsIdx === wspCalled.length - 1);
     } finally {
       DocRoom.newWebSocketPair = savedNWSP;
       persistence.bindState = savedBS;

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -14,8 +14,8 @@ import assert from 'assert';
 import esmock from 'esmock';
 
 import {
-  closeConn, getYDoc, invalidateFromAdmin, messageListener, persistence,
-  readState, setupWSConnection, setYDoc, showError, storeState, updateHandler, WSSharedDoc,
+  closeConn, createYDoc, invalidateFromAdmin, messageListener, persistence,
+  readState, setupWSConnection, showError, storeState, updateHandler, WSSharedDoc,
 } from '../src/shareddoc.js';
 import { aem2doc, doc2aem } from '../src/collab.js';
 
@@ -388,11 +388,7 @@ describe('Collab Test Suite', () => {
     const testYDoc = new WSSharedDoc(docName);
     testYDoc.conns = conns;
 
-    const m = setYDoc(docName, testYDoc);
-
-    assert(m.has(docName), 'Precondition');
-    invalidateFromAdmin(docName);
-    assert(!m.has(docName), 'Document should have been removed from global map');
+    invalidateFromAdmin(testYDoc);
 
     const res1 = ['close1', 'close2'];
     const res2 = ['close2', 'close1'];
@@ -411,7 +407,6 @@ describe('Collab Test Suite', () => {
       conns: new Map(),
     };
     mockDoc.awareness.states.set('123', null);
-    const docs = setYDoc(mockDoc.name, mockDoc);
 
     const called = [];
     const mockConn = {
@@ -422,17 +417,11 @@ describe('Collab Test Suite', () => {
     mockDoc.conns.set(mockConn, ids);
 
     assert.equal(0, called.length, 'Precondition');
-    assert(docs.get(mockDoc.name), 'Precondition');
     closeConn(mockDoc, mockConn);
     assert.deepStrictEqual(['close'], called);
     assert.equal(0, mockDoc.conns.size);
     assert.deepStrictEqual(['123'], awarenessEmitted[0][0].removed,
       'removeAwarenessStates should be called');
-
-    assert.equal(docs.get(mockDoc.name), undefined,
-      'Document should be removed from global map');
-
-    assert(docs.get(mockDoc.name) === undefined, 'Should have been removed from docs map');
   });
 
   it('Test close unknown connection', async () => {
@@ -467,7 +456,6 @@ describe('Collab Test Suite', () => {
       auth: 'myauth',
       authActions: ['read']
     };
-    pss.setYDoc(docName, testYDoc);
 
     const mockStorage = { list: () => new Map() };
 
@@ -476,7 +464,9 @@ describe('Collab Test Suite', () => {
     pss.persistence.update = async (d, v) => updated.set(d, v);
 
     assert.equal(0, updated.size, 'Precondition');
-    await pss.persistence.bindState(docName, testYDoc, mockConn, mockStorage);
+    const docs = new Map();
+    docs.set(docName, testYDoc);
+    await pss.persistence.bindState(docName, testYDoc, mockConn, mockStorage, docs);
 
     assert.equal(0, aem2DocCalled.length, 'Precondition, it\'s important to handle the doc setting async');
 
@@ -502,7 +492,6 @@ describe('Collab Test Suite', () => {
     const ydocUpdateCB = [];
     const testYDoc = new Y.Doc();
     testYDoc.on = (ev, f) => { if (ev === 'update') ydocUpdateCB.push(f); }
-    pss.setYDoc(docName, testYDoc);
 
     const called = []
     const mockStorage = {
@@ -520,7 +509,9 @@ describe('Collab Test Suite', () => {
     try {
       globalThis.setTimeout = () => setTimeoutCalls.push('setTimeout');
 
-      await pss.persistence.bindState(docName, testYDoc, {}, mockStorage);
+      const docs = new Map();
+      docs.set(docName, testYDoc);
+      await pss.persistence.bindState(docName, testYDoc, {}, mockStorage, docs);
     } finally {
       globalThis.setTimeout = savedSetTimeout;
     }
@@ -578,7 +569,6 @@ describe('Collab Test Suite', () => {
   it('Test bindstate falls back to daadmin on worker storage error', async () => {
     const docName = 'https://admin.da.live/source/foo/bar.html';
     const ydoc = new Y.Doc();
-    setYDoc(docName, ydoc);
 
     const storage = { list: async () => { throw new Error('yikes') } };
 
@@ -593,7 +583,9 @@ describe('Collab Test Suite', () => {
         <main><div>From daadmin</div></main>
         <footer></footer>
         </body>`;
-      await persistence.bindState(docName, ydoc, {}, storage);
+      const docs = new Map();
+      docs.set(docName, ydoc);
+      await persistence.bindState(docName, ydoc, {}, storage, docs);
 
       assert(doc2aem(ydoc).includes('<div><p>From daadmin</p></div>'));
     } finally {
@@ -620,7 +612,6 @@ describe('Collab Test Suite', () => {
         updObservers.push(fun);
       }
     };
-    pss.setYDoc(docName, ydoc);
 
     const savedSetTimeout = globalThis.setTimeout;
     const savedGet = pss.persistence.get;
@@ -641,7 +632,9 @@ describe('Collab Test Suite', () => {
         }
       };
 
-      await pss.persistence.bindState(docName, ydoc, {}, storage);
+      const docs = new Map();
+      docs.set(docName, ydoc);
+      await pss.persistence.bindState(docName, ydoc, {}, storage, docs);
 
       aem2doc('<main><div>newcontent</div></main>', ydoc);
 
@@ -674,7 +667,6 @@ describe('Collab Test Suite', () => {
 
     const ydoc = new Y.Doc();
     ydoc.daadmin = serviceBinding;
-    setYDoc(docName, ydoc);
     const conn = {};
     const storage = {
       deleteAll: async () => {},
@@ -711,7 +703,6 @@ describe('Collab Test Suite', () => {
 
     const ydoc = new Y.Doc();
     ydoc.daadmin = serviceBinding;
-    setYDoc(docName, ydoc);
     const conn = {};
 
     const deleteAllCalled = [];
@@ -734,7 +725,10 @@ describe('Collab Test Suite', () => {
         f();
       };
 
-      await persistence.bindState(docName, ydoc, conn, storage);
+      const docs = new Map();
+      docs.set(docName, ydoc);
+
+      await persistence.bindState(docName, ydoc, conn, storage, docs);
       assert.deepStrictEqual([true], deleteAllCalled);
       assert.equal(1, setTimeoutCalled.length, 'SetTimeout should have been called to update the doc');
     } finally {
@@ -753,7 +747,6 @@ describe('Collab Test Suite', () => {
         updObservers.push(fun);
       }
     };
-    setYDoc(docName, ydoc);
 
     const conn = {};
     const called = [];
@@ -773,7 +766,10 @@ describe('Collab Test Suite', () => {
       };
       persistence.get = async () => '<main><div>myinitial</div></main>';
 
-      await persistence.bindState(docName, ydoc, conn, storage);
+      const docs = new Map();
+      docs.set(docName, ydoc);
+
+      await persistence.bindState(docName, ydoc, conn, storage, docs);
       assert(doc2aem(ydoc).includes('myinitial'));
       assert.equal(2, updObservers.length);
 
@@ -796,7 +792,7 @@ describe('Collab Test Suite', () => {
     }
   });
 
-  it('Test getYDoc', async () => {
+  it('Test createYDoc', async () => {
     const savedBS = persistence.bindState;
 
     try {
@@ -809,7 +805,7 @@ describe('Collab Test Suite', () => {
       const mockConn = {};
 
       assert.equal(0, bsCalls.length, 'Precondition');
-      const doc = await getYDoc(docName, mockConn, {}, {});
+      const doc = await createYDoc(docName, mockConn, {}, {});
       assert.equal(1, bsCalls.length);
       assert.equal(bsCalls[0].dn, docName);
       assert.equal(bsCalls[0].d, doc);
@@ -817,10 +813,8 @@ describe('Collab Test Suite', () => {
 
       const daadmin = { foo: 'bar' }
       const env = { daadmin };
-      const doc2 = await getYDoc(docName, mockConn, env, {});
-      assert.equal(1, bsCalls.length, 'Should not have called bindstate again');
-      assert.equal(doc, doc2);
-      assert.equal('bar', doc.daadmin.foo, 'Should have bound daadmin now');
+      const doc2 = await createYDoc(docName, mockConn, env, {});
+      assert.equal('bar', doc2.daadmin.foo, 'Should have bound daadmin now');
     } finally {
       persistence.bindState = savedBS;
     }
@@ -904,7 +898,9 @@ describe('Collab Test Suite', () => {
 
       assert.equal(0, bindCalls.length, 'Precondition');
       assert.equal(0, eventListeners.size, 'Precondition');
-      await setupWSConnection(mockConn, docName, env, storage);
+
+      const ydoc = await createYDoc(docName, mockConn, env, storage, new Map(), new Map(), true); 
+      await setupWSConnection(mockConn, ydoc);
 
       assert.equal('arraybuffer', mockConn.binaryType);
       assert.equal(1, bindCalls.length);
@@ -951,10 +947,10 @@ describe('Collab Test Suite', () => {
         states: awarenessStates
       };
 
-      const ydoc = await getYDoc(docName, mockConn, {}, {}, true);
+      const ydoc = await createYDoc(docName, mockConn, {}, {}, new Map(), new Map(), true);
       ydoc.awareness = awareness;
 
-      await setupWSConnection(mockConn, docName, {}, {});
+      await setupWSConnection(mockConn, ydoc);
 
       assert.equal(0, closeCalls.length);
       assert.equal(2, sendCalls.length);


### PR DESCRIPTION
This is a first attempt to fix #76 

@karlpauls and I brainstormed and the current hypothesis is:

- The `DocRoom` is the Durable Object. 
- It contains multiple properties, including the `storage`.
- It creates `ydoc` instances which are cached in the [docs](https://github.com/adobe/da-collab/blob/main/src/shareddoc.js#L28) map. 
- This `docs` object is a global object, not necessarily bound to the Durable Object.
- Depending on how the worker memory is managed, it may happen that this global object still contains references to the DO (especially since the docs are attached to the `storage`)
- Sometimes, it may happen that the DO instance or the global object are updated / refreshed / recreated / ? and then there is some old reference still around.
- This "might" lead to the error

This is a pure hypothesis and we need to make sure:
1. the code is doing the same thing - all tests still work as before, just needed to tweak some of them
2. deploy in production and monitor to see if this occurs again

In any case, I think we should continue re-working the code: the `DocRoom` code should be isolated in its own file and, in the ideal scenario, contain all code it need - not sharing anything, to avoid those kind of memory mix. This would allow to clearly visualize what belongs to the DO (super singleton) vs what belong to the worker.