### PR TITLE
fix: null doc crashes aem2doc

### DIFF
--- a/src/collab.js
+++ b/src/collab.js
@@ -148,7 +148,6 @@ export function aem2doc(html, ydoc) {
     html = EMPTY_DOC;
   }
   const tree = fromHtml(html, { fragment: true });
-  console.log('tree', tree);
   const main = tree.children.find((child) => child.tagName === 'main') || { children: [] };
   fixImageLinks(main);
   removeComments(main);

--- a/src/collab.js
+++ b/src/collab.js
@@ -140,7 +140,13 @@ function removeComments(node) {
   return node;
 }
 
+export const EMPTY_DOC = '<body><header></header><main><div></div></main><footer></footer></body>';
+
 export function aem2doc(html, ydoc) {
+  if (!html) {
+    // eslint-disable-next-line no-param-reassign
+    html = EMPTY_DOC;
+  }
   const tree = fromHtml(html, { fragment: true });
   const main = tree.children.find((child) => child.tagName === 'main');
   fixImageLinks(main);

--- a/src/collab.js
+++ b/src/collab.js
@@ -148,7 +148,8 @@ export function aem2doc(html, ydoc) {
     html = EMPTY_DOC;
   }
   const tree = fromHtml(html, { fragment: true });
-  const main = tree.children.find((child) => child.tagName === 'main');
+  console.log('tree', tree);
+  const main = tree.children.find((child) => child.tagName === 'main') || { children: [] };
   fixImageLinks(main);
   removeComments(main);
   (main.children || []).forEach((parent) => {

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -16,7 +16,7 @@ import * as awarenessProtocol from 'y-protocols/awareness.js';
 import * as encoding from 'lib0/encoding.js';
 import * as decoding from 'lib0/decoding.js';
 import debounce from 'lodash/debounce.js';
-import { aem2doc, doc2aem } from './collab.js';
+import { aem2doc, doc2aem, EMPTY_DOC } from './collab.js';
 
 const wsReadyStateConnecting = 0;
 const wsReadyStateOpen = 1;
@@ -27,7 +27,6 @@ const gcEnabled = false;
 // The local cache of ydocs
 const docs = new Map();
 
-const EMPTY_DOC = '<main></main>';
 const messageSync = 0;
 const messageAwareness = 1;
 const MAX_STORAGE_KEYS = 128;
@@ -153,14 +152,19 @@ export const storeState = async (docName, state, storage, chunkSize = MAX_STORAG
 };
 
 export const showError = (ydoc, err) => {
-  const em = ydoc.getMap('error');
+  try {
+    const em = ydoc.getMap('error');
 
-  // Perform the change in a transaction to avoid seeing a partial error
-  ydoc.transact(() => {
-    em.set('timestamp', Date.now());
-    em.set('message', err.message);
-    em.set('stack', err.stack);
-  });
+    // Perform the change in a transaction to avoid seeing a partial error
+    ydoc.transact(() => {
+      em.set('timestamp', Date.now());
+      em.set('message', err.message);
+      em.set('stack', err.stack);
+    });
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('Error showing error', e, err);
+  }
 };
 
 export const persistence = {
@@ -330,6 +334,8 @@ export const persistence = {
       // The doc was not restored from worker persistence, so read it from da-admin,
       // but do this async to give the ydoc some time to get synced up first. Without
       // this timeout, the ydoc can get confused which may result in duplicated content.
+      // eslint-disable-next-line no-console
+      console.log('Could not be restored, trying to restore from da-admin', docName);
       setTimeout(() => {
         if (ydoc === docs.get(docName)) {
           const rootType = ydoc.getXmlFragment('prosemirror');
@@ -344,7 +350,7 @@ export const persistence = {
               console.log('Restored from da-admin', docName);
             } catch (error) {
               // eslint-disable-next-line no-console
-              console.error('Problem restoring state from da-admin', error);
+              console.error('Problem restoring state from da-admin', error, current);
               showError(ydoc, error);
             }
           });

--- a/test/collab.test.js
+++ b/test/collab.test.js
@@ -595,7 +595,7 @@ assert.equal(result, html);
     assert.equal(collapseWhitespace(result), collapseWhitespace(EMPTY_DOC));
   });
 
-  it.only('can parse no main', async () => {
+  it('can parse no main', async () => {
     const html = '<body><header></header><footer></footer></body>';
     const yDoc = new Y.Doc();
     aem2doc(html, yDoc);

--- a/test/collab.test.js
+++ b/test/collab.test.js
@@ -594,6 +594,14 @@ assert.equal(result, html);
     const result = doc2aem(yDoc);
     assert.equal(collapseWhitespace(result), collapseWhitespace(EMPTY_DOC));
   });
+
+  it.only('can parse no main', async () => {
+    const html = '<body><header></header><footer></footer></body>';
+    const yDoc = new Y.Doc();
+    aem2doc(html, yDoc);
+    const result = doc2aem(yDoc);
+    assert.equal(collapseWhitespace(result), collapseWhitespace(EMPTY_DOC));
+  });
 });
 
 

--- a/test/collab.test.js
+++ b/test/collab.test.js
@@ -12,7 +12,7 @@
 import assert from 'assert';
 import * as Y from 'yjs';
 import { readFileSync } from 'fs';
-import { aem2doc, doc2aem, tableToBlock } from '../src/collab.js';
+import { aem2doc, doc2aem, tableToBlock, EMPTY_DOC } from '../src/collab.js';
 
 const collapseTagWhitespace = (str) => str.replace(/>\s+</g, '><');
 const collapseWhitespace = (str) => collapseTagWhitespace(str.replace(/\s+/g, ' ')).trim();
@@ -577,6 +577,22 @@ assert.equal(result, html);
     aem2doc(html, yDoc);
     const result = doc2aem(yDoc);
     assert.equal(collapseWhitespace(result), collapseWhitespace(html));
+  });
+  
+  it('can parse empty doc', async () => {
+    const html = EMPTY_DOC;
+    const yDoc = new Y.Doc();
+    aem2doc(html, yDoc);
+    const result = doc2aem(yDoc);
+    assert.equal(collapseWhitespace(result), collapseWhitespace(EMPTY_DOC));
+  });
+
+  it('can parse null', async () => {
+    const html = null;
+    const yDoc = new Y.Doc();
+    aem2doc(html, yDoc);
+    const result = doc2aem(yDoc);
+    assert.equal(collapseWhitespace(result), collapseWhitespace(EMPTY_DOC));
   });
 });
 

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -17,7 +17,7 @@ import {
   closeConn, getYDoc, invalidateFromAdmin, messageListener, persistence,
   readState, setupWSConnection, setYDoc, showError, storeState, updateHandler, WSSharedDoc,
 } from '../src/shareddoc.js';
-import { aem2doc, doc2aem } from '../src/collab.js';
+import { aem2doc, doc2aem, EMPTY_DOC } from '../src/collab.js';
 
 function isSubArray(full, sub) {
   if (sub.length === 0) {
@@ -534,7 +534,7 @@ describe('Collab Test Suite', () => {
 
     await ydocUpdateCB[0]();
     await ydocUpdateCB[1]();
-    assert.deepStrictEqual(['<main></main>'], updateCalled);
+    assert.deepStrictEqual([EMPTY_DOC], updateCalled);
   });
 
   it('Test bindstate read from worker storage', async () => {


### PR DESCRIPTION
Should fix observed error: 

```
Problem restoring state from da-admin
TypeError: Cannot read properties of undefined (reading 'children')
```

Also adding more debugs for next round of errors.