### PR TITLE
chore: refactor logs

### DIFF
--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -40,8 +40,6 @@ const MAX_STORAGE_VALUE_SIZE = 131072;
  */
 export const closeConn = (doc, conn) => {
   try {
-    // eslint-disable-next-line no-console
-    console.log('Closing connection', doc.name, doc.conns.size);
     if (doc.conns.has(conn)) {
       const controlledIds = doc.conns.get(conn);
       doc.conns.delete(conn);
@@ -51,13 +49,11 @@ export const closeConn = (doc, conn) => {
       } catch (err) {
         // we can ignore an exception here, closing the connection will remove the awareness states
         // eslint-disable-next-line no-console
-        console.error('Error removing awareness states', err);
+        console.error('[docroom] Error while removing awareness states', err);
         /* c8 ignore end */
       }
 
       if (doc.conns.size === 0) {
-        // eslint-disable-next-line no-console
-        console.log('No connections left, removing document from local map', doc.name);
         docs.delete(doc.name);
       }
     }
@@ -66,7 +62,7 @@ export const closeConn = (doc, conn) => {
     /* c8 ignore start */
     // we can ignore an exception here, connection will be closed anyway
     // eslint-disable-next-line no-console
-    console.error('Error closing connection', e);
+    console.error('[docroom] Error while closing connection', e);
     /* c8 ignore end */
   }
 };
@@ -80,7 +76,7 @@ const send = (doc, conn, m) => {
     conn.send(m, (err) => err != null && closeConn(doc, conn));
   } catch (e) {
     // eslint-disable-next-line no-console
-    console.error('Error sending message', e);
+    console.error('[docroom] Error while sending message', e);
     closeConn(doc, conn);
   }
 };
@@ -96,20 +92,20 @@ export const readState = async (docName, storage) => {
   const stored = await storage.list();
   if (stored.size === 0) {
     // eslint-disable-next-line no-console
-    console.log('No stored doc in persistence');
+    console.log('[docroom] No stored doc in persistence');
     return undefined;
   }
 
   if (stored.get('doc') !== docName) {
     // eslint-disable-next-line no-console
-    console.log('Docname mismatch in persistence. Expected:', docName, 'found:', stored.get('doc'), 'Deleting storage');
+    console.log('[docroom] Docname mismatch in persistence. Expected:', docName, 'found:', stored.get('doc'), 'Deleting storage');
     await storage.deleteAll();
     return undefined;
   }
 
   if (stored.has('docstore')) {
     // eslint-disable-next-line no-console
-    console.log('Document found in persistence');
+    console.log('[docroom] Document found in persistence');
     return stored.get('docstore');
   }
 
@@ -124,7 +120,7 @@ export const readState = async (docName, storage) => {
     }
   }
   // eslint-disable-next-line no-console
-  console.log('Document data read');
+  console.log('[docroom] Document data read');
   return new Uint8Array(data);
 };
 
@@ -164,7 +160,7 @@ export const storeState = async (docName, state, storage, chunkSize = MAX_STORAG
 
     if (j >= MAX_STORAGE_KEYS) {
       // eslint-disable-next-line no-console
-      console.error('Object too big for worker storage', docName, j, MAX_STORAGE_KEYS);
+      console.error('[docroom] Object too big for worker storage', docName, j, MAX_STORAGE_KEYS);
       throw new Error('Object too big for worker storage');
     }
 
@@ -187,7 +183,7 @@ export const showError = (ydoc, err) => {
     });
   } catch (e) {
     // eslint-disable-next-line no-console
-    console.error('Error showing error', e, err);
+    console.error('[docroom] Error while showing error', e, err);
   }
 };
 
@@ -214,7 +210,7 @@ export const persistence = {
       return null;
     } else {
       // eslint-disable-next-line no-console
-      console.error(`Unable to get resource from da-admin: ${initialReq.status} - ${initialReq.statusText}`);
+      console.error(`[docroom] Unable to get resource from da-admin: ${initialReq.status} - ${initialReq.statusText}`);
       throw new Error(`unable to get resource - status: ${initialReq.status}`);
     }
   },
@@ -237,7 +233,7 @@ export const persistence = {
     const allReadOnly = keys.length > 0 && keys.every((con) => con.readOnly === true);
     if (allReadOnly) {
       // eslint-disable-next-line no-console
-      console.log('All connections are read only, not storing');
+      console.log('[docroom] All connections are read only, not storing');
       return { ok: true };
     }
     const auth = keys
@@ -253,9 +249,17 @@ export const persistence = {
 
     if (blob.size < 84) {
       // eslint-disable-next-line no-console
-      console.warn('Writting back an empty document', ydoc.name, blob.size);
+      console.warn('[docroom] Writting back an empty document', ydoc.name, blob.size);
     }
-    const { ok, status, statusText } = await ydoc.daadmin.fetch(ydoc.name, opts);
+
+    const {
+      ok, status, statusText, body,
+    } = await ydoc.daadmin.fetch(ydoc.name, opts);
+
+    if (body) {
+      // tell CloudFlare to consider the request as completed
+      body.cancel();
+    }
 
     return {
       ok,
@@ -288,7 +292,7 @@ export const persistence = {
       }
     } catch (err) {
       // eslint-disable-next-line no-console
-      console.error('Failed to update document', err);
+      console.error('[docroom] Failed to update document', err);
       showError(ydoc, err);
     }
     if (closeAll) {
@@ -343,7 +347,7 @@ export const persistence = {
           restored = true;
 
           // eslint-disable-next-line no-console
-          console.log('Restored from worker persistence', docName);
+          console.log('[docroom] Restored from worker persistence', docName);
         }
       }
 
@@ -354,7 +358,7 @@ export const persistence = {
       }
     } catch (error) {
       // eslint-disable-next-line no-console
-      console.error('Problem restoring state from worker storage', error);
+      console.error('[docroom] Problem restoring state from worker storage', error);
       showError(ydoc, error);
     }
 
@@ -363,7 +367,7 @@ export const persistence = {
       // but do this async to give the ydoc some time to get synced up first. Without
       // this timeout, the ydoc can get confused which may result in duplicated content.
       // eslint-disable-next-line no-console
-      console.log('Could not be restored, trying to restore from da-admin', docName);
+      console.log('[docroom] Could not be restored, trying to restore from da-admin', docName);
       setTimeout(() => {
         if (ydoc === docs.get(docName)) {
           const rootType = ydoc.getXmlFragment('prosemirror');
@@ -375,10 +379,10 @@ export const persistence = {
               aem2doc(current, ydoc);
 
               // eslint-disable-next-line no-console
-              console.log('Restored from da-admin', docName);
+              console.log('[docroom] Restored from da-admin', docName);
             } catch (error) {
               // eslint-disable-next-line no-console
-              console.error('Problem restoring state from da-admin', error, current);
+              console.error('[docroom] Problem restoring state from da-admin', error, current);
               showError(ydoc, error);
             }
           });
@@ -477,6 +481,10 @@ export const getYDoc = async (docname, conn, env, storage, timingData, gc = true
     doc.conns.set(conn, new Set());
   }
 
+  const uniqueConnections = new Set(new Array(doc.conns.keys()).map((c) => c.auth));
+  // eslint-disable-next-line no-console
+  console.log(`[docroom] Getting ydoc ${docname}`, `Connections (unique / total): ${uniqueConnections.size} / ${doc.conns.size}`);
+
   // Store the service binding to da-admin which we receive through the environment in the doc
   doc.daadmin = env.daadmin;
   if (!doc.promise) {
@@ -543,14 +551,8 @@ export const messageListener = (conn, doc, message) => {
         break;
     }
   } catch (err) {
-    // eslint-disable-next-line no-console, no-nested-ternary
-    console.error('messageListener - Received message', doc.name, messageType === messageSync ? 'sync' : (messageType === messageAwareness ? 'awareness' : 'unknown'));
-    // eslint-disable-next-line no-console, no-nested-ternary
-    console.error('messageListener - Stack', err.stack);
-    // eslint-disable-next-line no-console, no-nested-ternary
-    console.error('messageListener - Message', err.message);
     // eslint-disable-next-line no-console
-    console.error('Error in messageListener', err);
+    console.error('[docroom] messageListener - Message', err.stack, err);
     showError(doc, err);
   }
 };
@@ -565,7 +567,7 @@ export const messageListener = (conn, doc, message) => {
  */
 export const invalidateFromAdmin = async (docName) => {
   // eslint-disable-next-line no-console
-  console.log('Invalidate from Admin received', docName);
+  console.log('[worker] Invalidate from Admin received', docName);
   const ydoc = docs.get(docName);
   if (ydoc) {
     // As we are closing all connections, the ydoc will be removed from the docs map
@@ -574,7 +576,7 @@ export const invalidateFromAdmin = async (docName) => {
     return true;
   } else {
     // eslint-disable-next-line no-console
-    console.log('Document not found', docName);
+    console.log('[worker] Document not found', docName);
   }
   return false;
 };
@@ -620,7 +622,7 @@ export const setupWSConnection = async (conn, docName, env, storage) => {
     }
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.error('Error in setupWSConnection', err);
+    console.error('[docroom] Error while setting up WSConnection', docName, err);
   }
 
   return timingData;


### PR DESCRIPTION
Cleanup logs, add more, add category (worker vs docroom).
Also added a `body.cancel()` to avoid having cancelled execution in the logs. This seems to be a Cloudflare best practice (either consume the body or cancel it to avoid the worker to keep the connection opened, wait and timeout)