### PR TITLE
feat: allow read-only connections to write comment data

### DIFF
--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -560,6 +560,40 @@ export const getYDoc = async (docname, conn, env, storage, timingData, gc = true
 // For testing
 export const setYDoc = (docname, ydoc) => docs.set(docname, ydoc);
 
+/**
+ * Returns true if the Yjs update only touches the 'comments' named type.
+ * Used to allow read-only WebSocket connections to write comment data.
+ * @param {Uint8Array} update
+ * @returns {boolean}
+ */
+export function isCommentOnlyUpdate(update) {
+  try {
+    const testDoc = new Y.Doc({ gc: false });
+    const commentsMap = testDoc.getMap('comments');
+    let onlyComments = true;
+
+    testDoc.on('afterTransaction', (tr) => {
+      tr.changed.forEach((_, type) => {
+        let ancestor = type;
+        let underComments = false;
+        while (ancestor) {
+          if (ancestor === commentsMap) {
+            underComments = true;
+            break;
+          }
+          ancestor = ancestor.parent;
+        }
+        if (!underComments) onlyComments = false;
+      });
+    });
+
+    Y.applyUpdate(testDoc, update);
+    return onlyComments;
+  } catch {
+    return false;
+  }
+}
+
 // This read sync message handles readonly connections
 const readSyncMessage = (decoder, encoder, doc, readOnly, transactionOrigin) => {
   const messageType = decoding.readVarUint(decoder);
@@ -568,10 +602,20 @@ const readSyncMessage = (decoder, encoder, doc, readOnly, transactionOrigin) => 
       syncProtocol.readSyncStep1(decoder, encoder, doc);
       break;
     case syncProtocol.messageYjsSyncStep2:
-      if (!readOnly) syncProtocol.readSyncStep2(decoder, doc, transactionOrigin);
+      if (readOnly) {
+        const update = decoding.readVarUint8Array(decoder);
+        if (isCommentOnlyUpdate(update)) Y.applyUpdate(doc, update, transactionOrigin);
+      } else {
+        syncProtocol.readSyncStep2(decoder, doc, transactionOrigin);
+      }
       break;
     case syncProtocol.messageYjsUpdate:
-      if (!readOnly) syncProtocol.readUpdate(decoder, doc, transactionOrigin);
+      if (readOnly) {
+        const update = decoding.readVarUint8Array(decoder);
+        if (isCommentOnlyUpdate(update)) Y.applyUpdate(doc, update, transactionOrigin);
+      } else {
+        syncProtocol.readUpdate(decoder, doc, transactionOrigin);
+      }
       break;
     default:
       throw new Error('Unknown message type');

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -17,7 +17,7 @@ import {
   aem2doc, doc2aem, doc2json, EMPTY_DOC,
 } from '@da-tools/da-parser';
 import {
-  closeConn, getYDoc, invalidateFromAdmin, messageListener, persistence,
+  closeConn, getYDoc, invalidateFromAdmin, isCommentOnlyUpdate, messageListener, persistence,
   readState, setupWSConnection, setYDoc, showError, storeState, updateHandler, WSSharedDoc,
 } from '../src/shareddoc.js';
 
@@ -1532,5 +1532,33 @@ describe('Collab Test Suite', () => {
       globalThis.setTimeout = savedSetTimeout;
       persistence.get = savedGet;
     }
+  });
+});
+
+describe('isCommentOnlyUpdate', () => {
+  it('returns true when update only touches comments map', () => {
+    const ydoc = new Y.Doc();
+    const comments = ydoc.getMap('comments');
+    let capturedUpdate;
+    ydoc.on('update', (update) => {
+      capturedUpdate = update;
+    });
+    comments.set('test-id', new Y.Map());
+    assert.equal(isCommentOnlyUpdate(capturedUpdate), true);
+  });
+
+  it('returns false when update touches prosemirror fragment', () => {
+    const ydoc = new Y.Doc();
+    const pm = ydoc.getXmlFragment('prosemirror');
+    let capturedUpdate;
+    ydoc.on('update', (update) => {
+      capturedUpdate = update;
+    });
+    pm.insert(0, [new Y.XmlText('hello')]);
+    assert.equal(isCommentOnlyUpdate(capturedUpdate), false);
+  });
+
+  it('returns false for an empty or invalid update', () => {
+    assert.equal(isCommentOnlyUpdate(new Uint8Array()), false);
   });
 });


### PR DESCRIPTION
Allows read-only users to write _only_ comment data.

Should be merged with https://github.com/adobe/da-live/pull/882