### PR TITLE
fix: propagate HTTP status from persistence.get through DocRoom.fetch response

### DIFF
--- a/src/edge.js
+++ b/src/edge.js
@@ -379,7 +379,9 @@ export class DocRoom {
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('[docroom] Error while fetching', err);
-      return new Response('Internal Server Error', { status: 500 });
+      const status = err.status ?? 500;
+      const body = status === 500 ? 'Internal Server Error' : err.message;
+      return new Response(body, { status });
     }
   }
 

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -221,7 +221,9 @@ export const persistence = {
     } else {
       // eslint-disable-next-line no-console
       console.error(`[docroom] Unable to get resource from da-admin: ${initialReq.status} - ${initialReq.statusText}`);
-      throw new Error(`unable to get resource - status: ${initialReq.status}`);
+      const err = new Error(`unable to get resource - status: ${initialReq.status}`);
+      err.status = initialReq.status;
+      throw err;
     }
   },
 

--- a/test/edge.test.js
+++ b/test/edge.test.js
@@ -419,7 +419,9 @@ describe('Worker test suite', () => {
       persistence.bindState = async () => {
         // eslint-disable-next-line max-len
         await sleep(1); // the real bindState is async and we only reset the failed doc in the promise
-        throw new Error('unable to get resource - status: 404');
+        const err = new Error('unable to get resource - status: 404');
+        err.status = 404;
+        throw err;
       };
 
       const wsp0 = {};
@@ -444,7 +446,83 @@ describe('Worker test suite', () => {
 
       const resp = await dr.fetch(req, {}, 306);
 
-      // Should return 500 error when bindState fails
+      // Should propagate the 404 status from the error
+      assert.equal(404, resp.status);
+      assert.equal('unable to get resource - status: 404', await resp.text());
+    } finally {
+      DocRoom.newWebSocketPair = savedNWSP;
+      persistence.bindState = savedBS;
+    }
+  });
+
+  it('Test DocRoom fetch propagates 401 when auth check fails', async () => {
+    const savedNWSP = DocRoom.newWebSocketPair;
+    const savedBS = persistence.bindState;
+
+    try {
+      persistence.bindState = async () => {
+        await sleep(1);
+        const err = new Error('unable to get resource - status: 401');
+        err.status = 401;
+        throw err;
+      };
+
+      const wsp0 = {};
+      const wsp1 = {
+        accept() {},
+        addEventListener() {},
+        close() {},
+      };
+      DocRoom.newWebSocketPair = () => [wsp0, wsp1];
+
+      const daadmin = { fetch: async () => ({ ok: true }) };
+      const dr = new DocRoom({ storage: null }, { daadmin });
+      const headers = new Map();
+      headers.set('Upgrade', 'websocket');
+      headers.set('X-collab-room', 'http://foo.bar/test.html');
+      headers.set('X-auth-actions', 'read=allow,write=allow');
+
+      const req = { headers, url: 'http://localhost:4711/' };
+
+      const resp = await dr.fetch(req, {}, 306);
+
+      assert.equal(401, resp.status);
+      assert.equal('unable to get resource - status: 401', await resp.text());
+    } finally {
+      DocRoom.newWebSocketPair = savedNWSP;
+      persistence.bindState = savedBS;
+    }
+  });
+
+  it('Test DocRoom fetch returns 500 for unexpected errors', async () => {
+    const savedNWSP = DocRoom.newWebSocketPair;
+    const savedBS = persistence.bindState;
+
+    try {
+      persistence.bindState = async () => {
+        await sleep(1);
+        throw new Error('some unexpected internal error');
+      };
+
+      const wsp0 = {};
+      const wsp1 = {
+        accept() {},
+        addEventListener() {},
+        close() {},
+      };
+      DocRoom.newWebSocketPair = () => [wsp0, wsp1];
+
+      const daadmin = { fetch: async () => ({ ok: true }) };
+      const dr = new DocRoom({ storage: null }, { daadmin });
+      const headers = new Map();
+      headers.set('Upgrade', 'websocket');
+      headers.set('X-collab-room', 'http://foo.bar/test.html');
+      headers.set('X-auth-actions', 'read=allow,write=allow');
+
+      const req = { headers, url: 'http://localhost:4711/' };
+
+      const resp = await dr.fetch(req, {}, 306);
+
       assert.equal(500, resp.status);
       assert.equal('Internal Server Error', await resp.text());
     } finally {

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -186,6 +186,7 @@ describe('Collab Test Suite', () => {
       assert.fail('Should have thrown an error');
     } catch (error) {
       assert(error.toString().includes('unable to get resource - status: 404'));
+      assert.equal(404, error.status, 'Error must carry the HTTP status for upstream propagation');
     }
   });
 
@@ -205,6 +206,33 @@ describe('Collab Test Suite', () => {
     } catch (error) {
       // expected
       assert(error.toString().includes('unable to get resource - status: 500'));
+      assert.equal(500, error.status, 'Error must carry the HTTP status for upstream propagation');
+    }
+  });
+
+  it('Test persistence get 401 carries status for propagation', async () => {
+    const daadmin = {
+      fetch: async () => ({ ok: false, status: 401, statusText: 'Unauthorized' }),
+    };
+    try {
+      await persistence.get('foo', 'auth', daadmin);
+      assert.fail('Should have thrown an error');
+    } catch (error) {
+      assert.equal(401, error.status, 'Error must carry 401 status');
+      assert(error.message.includes('401'));
+    }
+  });
+
+  it('Test persistence get 403 carries status for propagation', async () => {
+    const daadmin = {
+      fetch: async () => ({ ok: false, status: 403, statusText: 'Forbidden' }),
+    };
+    try {
+      await persistence.get('foo', 'auth', daadmin);
+      assert.fail('Should have thrown an error');
+    } catch (error) {
+      assert.equal(403, error.status, 'Error must carry 403 status');
+      assert(error.message.includes('403'));
     }
   });
 


### PR DESCRIPTION
## Summary

- `persistence.get()` now attaches `err.status = initialReq.status` to thrown errors so callers can read the original HTTP status code
- `DocRoom.fetch` catch block reads `err.status ?? 500` — 401/403/404 errors are now returned with their real status code; unknown errors still return 500 with "Internal Server Error"
- For non-500 responses, the error message is used as the body to give clients actionable context

## Background

When da-admin returns 401 or 403 (auth failure), the WebSocket upgrade path in `DocRoom.fetch` was catching those errors and always returning 500 "Internal Server Error". This made it impossible for clients and monitoring to distinguish auth failures from actual server bugs.

Observed in production logs: 401/403 auth errors showing up as 500 responses, making them look like worker crashes rather than expected auth rejections.

## Test plan

- [ ] All 86 tests pass (`npm test`)
- [ ] `Test persistence get 404` — verifies error carries `status: 404`
- [ ] `Test persistence get throws` — verifies error carries `status: 500`
- [ ] `Test persistence get 401 carries status for propagation` — new test for 401
- [ ] `Test persistence get 403 carries status for propagation` — new test for 403
- [ ] `Test DocRoom fetch fails when document deleted after auth` — updated: now expects 404
- [ ] `Test DocRoom fetch propagates 401 when auth check fails` — new test
- [ ] `Test DocRoom fetch returns 500 for unexpected errors` — new test verifying untyped errors still produce 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)