### PR TITLE
fix: demote expected platform events to info and eliminate unknown worker outcomes

### DIFF
--- a/src/edge.js
+++ b/src/edge.js
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { invalidateFromAdmin, setupWSConnection } from './shareddoc.js';
+import { invalidateFromAdmin, isExpectedPlatformEvent, setupWSConnection } from './shareddoc.js';
 
 /**
  * This is the Edge Worker, built using Durable Objects!
@@ -200,7 +200,8 @@ export async function handleApiRequest(request, env) {
     [, authActions] = daActions.split('=');
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.error(`[worker] Unable to handle API request ${docName}`, err);
+    const log = isExpectedPlatformEvent(err) ? console.log : console.error;
+    log(`[worker] Unable to handle API request ${docName}`, err);
     return new Response('unable to get resource', { status: 500 });
   }
 
@@ -239,7 +240,8 @@ export async function handleApiRequest(request, env) {
     return await roomObject.fetch(req);
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.error(`[worker] Error fetching the doc from the room ${docName}`, err);
+    const log = isExpectedPlatformEvent(err) ? console.log : console.error;
+    log(`[worker] Error fetching the doc from the room ${docName}`, err);
     return new Response('unable to get resource', { status: 500 });
   }
 }
@@ -348,64 +350,52 @@ export class DocRoom {
         return new Response('expected docName', { status: 400 });
       }
 
-      const timingBeforeSetupWebsocket = Date.now();
       // To accept the WebSocket request, we create a WebSocketPair (which is like a socketpair,
       // i.e. two WebSockets that talk to each other), we return one end of the pair in the
       // response, and we operate on the other end. Note that this API is not part of the
       // Fetch API standard; unfortunately, the Fetch API / Service Workers specs do not define
       // any way to act as a WebSocket server today.
-      const pair = DocRoom.newWebSocketPair();
+      const [client, server] = DocRoom.newWebSocketPair();
 
-      // We're going to take pair[1] as our end, and return pair[0] to the client.
-      const timingData = await this.handleSession(pair[1], docName, auth, authActions);
-      const timingSetupWebSocketDuration = Date.now() - timingBeforeSetupWebsocket;
+      server.accept();
+      // eslint-disable-next-line no-param-reassign
+      server.auth = auth;
+      if (!authActions.split(',').includes('write')) {
+        // eslint-disable-next-line no-param-reassign
+        server.readOnly = true;
+      }
+      // eslint-disable-next-line no-console
+      console.log(`[docroom] Setting up WSConnection for ${docName} with auth(${auth
+        ? auth.substring(0, auth.indexOf(' ')) : 'none'})`);
+
+      // Run session setup asynchronously so the 101 response is returned immediately.
+      // This ensures Cloudflare records a known ("ok") outcome for this fetch event even
+      // when the client disconnects while the document is still loading.
+      setupWSConnection(server, docName, this.env, this.storage).catch((err) => {
+        // eslint-disable-next-line no-console
+        const log = isExpectedPlatformEvent(err) ? console.log : console.error;
+        log('[docroom] Error during session setup', docName, err);
+        try {
+          server.close(1011, err.message);
+        } catch (_) { /* already closed */ }
+      });
 
       const reqHeaders = request.headers;
       const respheaders = new Headers({
         'X-1-timing-da-admin-head-duration': reqHeaders.get('X-timing-da-admin-head-duration'),
         'X-2-timing-docroom-get-duration': reqHeaders.get('X-timing-docroom-get-duration'),
-        'X-4-timing-da-admin-get-duration': timingData.get('timingDaAdminGetDuration'),
-        'X-5-timing-read-state-duration': timingData.get('timingReadStateDuration'),
-        'X-7-timing-setup-websocket-duration': timingSetupWebSocketDuration,
-        'X-9-timing-full-duration': Date.now() - reqHeaders.get('X-timing-start'),
       });
       const protocols = reqHeaders.get('sec-websocket-protocol')?.split(',');
       if (protocols?.includes('yjs')) {
         respheaders.set('sec-websocket-protocol', 'yjs');
       }
 
-      // Now we return the other end of the pair to the client.
-      return new Response(null, { status: successCode, headers: respheaders, webSocket: pair[0] });
+      return new Response(null, { status: successCode, headers: respheaders, webSocket: client });
     } catch (err) {
       // eslint-disable-next-line no-console
-      console.error('[docroom] Error while fetching', err);
+      const log = isExpectedPlatformEvent(err) ? console.log : console.error;
+      log('[docroom] Error while fetching', err);
       return new Response('Internal Server Error', { status: 500 });
     }
-  }
-
-  /**
-   * Implements our WebSocket-based protocol.
-   * @param {WebSocket} webSocket - The WebSocket connection to the client
-   * @param {string} docName - The document name
-   * @param {string} auth - The authorization header
-   * @param {string} authActions
-   */
-  async handleSession(webSocket, docName, auth, authActions) {
-    // Accept our end of the WebSocket. This tells the runtime that we'll be terminating the
-    // WebSocket in JavaScript, not sending it elsewhere.
-    webSocket.accept();
-    // eslint-disable-next-line no-param-reassign
-    webSocket.auth = auth;
-
-    if (!authActions.split(',').includes('write')) {
-      // eslint-disable-next-line no-param-reassign
-      webSocket.readOnly = true;
-    }
-    // eslint-disable-next-line no-console
-    console.log(`[docroom] Setting up WSConnection for ${docName} with auth(${webSocket.auth
-      ? webSocket.auth.substring(0, webSocket.auth.indexOf(' ')) : 'none'})`);
-
-    const timingData = await setupWSConnection(webSocket, docName, this.env, this.storage);
-    return timingData;
   }
 }

--- a/src/edge.js
+++ b/src/edge.js
@@ -387,7 +387,7 @@ export class DocRoom {
    * @param {string} auth - The authorization header
    * @param {string} authActions
    */
-  handleSession(webSocket, docName, auth, authActions) {
+  async handleSession(webSocket, docName, auth, authActions) {
     webSocket.accept();
     // eslint-disable-next-line no-param-reassign
     webSocket.auth = auth;
@@ -399,16 +399,15 @@ export class DocRoom {
     console.log(`[docroom] Setting up WSConnection for ${docName} with auth(${auth
       ? auth.substring(0, auth.indexOf(' ')) : 'none'})`);
 
-    // Run session setup asynchronously so the 101 response is returned immediately.
-    // This ensures Cloudflare records a known ("ok") outcome for this fetch event even
-    // when the client disconnects while the document is still loading.
-    setupWSConnection(webSocket, docName, this.env, this.storage).catch((err) => {
+    try {
+      await setupWSConnection(webSocket, docName, this.env, this.storage);
+    } catch (err) {
       // eslint-disable-next-line no-console
       const log = isExpectedPlatformEvent(err) ? console.log : console.error;
       log('[docroom] Error during session setup', docName, err);
       try {
         webSocket.close(1011, err.message);
       } catch (_) { /* already closed */ }
-    });
+    }
   }
 }

--- a/src/edge.js
+++ b/src/edge.js
@@ -357,28 +357,7 @@ export class DocRoom {
       // any way to act as a WebSocket server today.
       const [client, server] = DocRoom.newWebSocketPair();
 
-      server.accept();
-      // eslint-disable-next-line no-param-reassign
-      server.auth = auth;
-      if (!authActions.split(',').includes('write')) {
-        // eslint-disable-next-line no-param-reassign
-        server.readOnly = true;
-      }
-      // eslint-disable-next-line no-console
-      console.log(`[docroom] Setting up WSConnection for ${docName} with auth(${auth
-        ? auth.substring(0, auth.indexOf(' ')) : 'none'})`);
-
-      // Run session setup asynchronously so the 101 response is returned immediately.
-      // This ensures Cloudflare records a known ("ok") outcome for this fetch event even
-      // when the client disconnects while the document is still loading.
-      setupWSConnection(server, docName, this.env, this.storage).catch((err) => {
-        // eslint-disable-next-line no-console
-        const log = isExpectedPlatformEvent(err) ? console.log : console.error;
-        log('[docroom] Error during session setup', docName, err);
-        try {
-          server.close(1011, err.message);
-        } catch (_) { /* already closed */ }
-      });
+      this.handleSession(server, docName, auth, authActions);
 
       const reqHeaders = request.headers;
       const respheaders = new Headers({
@@ -397,5 +376,37 @@ export class DocRoom {
       log('[docroom] Error while fetching', err);
       return new Response('Internal Server Error', { status: 500 });
     }
+  }
+
+  /**
+   * Implements our WebSocket-based protocol.
+   * @param {WebSocket} webSocket - The WebSocket connection to the client
+   * @param {string} docName - The document name
+   * @param {string} auth - The authorization header
+   * @param {string} authActions
+   */
+  handleSession(webSocket, docName, auth, authActions) {
+    webSocket.accept();
+    // eslint-disable-next-line no-param-reassign
+    webSocket.auth = auth;
+    if (!authActions.split(',').includes('write')) {
+      // eslint-disable-next-line no-param-reassign
+      webSocket.readOnly = true;
+    }
+    // eslint-disable-next-line no-console
+    console.log(`[docroom] Setting up WSConnection for ${docName} with auth(${auth
+      ? auth.substring(0, auth.indexOf(' ')) : 'none'})`);
+
+    // Run session setup asynchronously so the 101 response is returned immediately.
+    // This ensures Cloudflare records a known ("ok") outcome for this fetch event even
+    // when the client disconnects while the document is still loading.
+    setupWSConnection(webSocket, docName, this.env, this.storage).catch((err) => {
+      // eslint-disable-next-line no-console
+      const log = isExpectedPlatformEvent(err) ? console.log : console.error;
+      log('[docroom] Error during session setup', docName, err);
+      try {
+        webSocket.close(1011, err.message);
+      } catch (_) { /* already closed */ }
+    });
   }
 }

--- a/src/edge.js
+++ b/src/edge.js
@@ -9,7 +9,9 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { invalidateFromAdmin, isExpectedPlatformEvent, setupWSConnection } from './shareddoc.js';
+import {
+  invalidateFromAdmin, logError, setupWSConnection,
+} from './shareddoc.js';
 
 /**
  * This is the Edge Worker, built using Durable Objects!
@@ -199,9 +201,7 @@ export async function handleApiRequest(request, env) {
     const daActions = initialReq.headers.get('X-da-actions') ?? '';
     [, authActions] = daActions.split('=');
   } catch (err) {
-    // eslint-disable-next-line no-console
-    const log = isExpectedPlatformEvent(err) ? console.log : console.error;
-    log(`[worker] Unable to handle API request ${docName}`, err);
+    logError(err, `[worker] Unable to handle API request ${docName}`, err);
     return new Response('unable to get resource', { status: 500 });
   }
 
@@ -239,9 +239,7 @@ export async function handleApiRequest(request, env) {
     // object, regardless of the hostname in the request's URL.
     return await roomObject.fetch(req);
   } catch (err) {
-    // eslint-disable-next-line no-console
-    const log = isExpectedPlatformEvent(err) ? console.log : console.error;
-    log(`[worker] Error fetching the doc from the room ${docName}`, err);
+    logError(err, `[worker] Error fetching the doc from the room ${docName}`, err);
     return new Response('unable to get resource', { status: 500 });
   }
 }
@@ -371,9 +369,7 @@ export class DocRoom {
 
       return new Response(null, { status: successCode, headers: respheaders, webSocket: client });
     } catch (err) {
-      // eslint-disable-next-line no-console
-      const log = isExpectedPlatformEvent(err) ? console.log : console.error;
-      log('[docroom] Error while fetching', err);
+      logError(err, '[docroom] Error while fetching', err);
       const status = err.status ?? 500;
       const body = status === 500 ? 'Internal Server Error' : err.message;
       return new Response(body, { status });
@@ -402,9 +398,7 @@ export class DocRoom {
     try {
       await setupWSConnection(webSocket, docName, this.env, this.storage);
     } catch (err) {
-      // eslint-disable-next-line no-console
-      const log = isExpectedPlatformEvent(err) ? console.log : console.error;
-      log('[docroom] Error during session setup', docName, err);
+      logError(err, '[docroom] Error during session setup', docName, err);
       try {
         webSocket.close(1011, err.message);
       } catch (_) { /* already closed */ }

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -22,6 +22,17 @@ import {
 const wsReadyStateConnecting = 0;
 const wsReadyStateOpen = 1;
 
+/**
+ * Returns true for Cloudflare platform events that are expected during normal operation
+ * (deployments, DO live migrations) and should not be treated as errors.
+ * @param {Error} err
+ */
+export const isExpectedPlatformEvent = (err) => {
+  const msg = err?.message ?? '';
+  return msg.includes('This script has been upgraded')
+    || msg.includes('cannot access storage because object has moved to a different machine');
+};
+
 // disable gc when using snapshots!
 const gcEnabled = false;
 
@@ -56,7 +67,8 @@ export const closeConn = (doc, conn) => {
       } catch (err) {
         // we can ignore an exception here, closing the connection will remove the awareness states
         // eslint-disable-next-line no-console
-        console.error('[docroom] Error while removing awareness states', err);
+        const log = isExpectedPlatformEvent(err) ? console.log : console.error;
+        log('[docroom] Error while removing awareness states', err);
         /* c8 ignore end */
       }
 
@@ -71,7 +83,8 @@ export const closeConn = (doc, conn) => {
     /* c8 ignore start */
     // we can ignore an exception here, connection will be closed anyway
     // eslint-disable-next-line no-console
-    console.error('[docroom] Error while closing connection', e);
+    const log = isExpectedPlatformEvent(e) ? console.log : console.error;
+    log('[docroom] Error while closing connection', e);
     /* c8 ignore end */
   }
 };
@@ -85,7 +98,8 @@ const send = (doc, conn, m) => {
     conn.send(m, (err) => err != null && closeConn(doc, conn));
   } catch (e) {
     // eslint-disable-next-line no-console
-    console.error('[docroom] Error while sending message', e);
+    const log = isExpectedPlatformEvent(e) ? console.log : console.error;
+    log('[docroom] Error while sending message', e);
     closeConn(doc, conn);
   }
 };
@@ -378,8 +392,9 @@ export const persistence = {
       }
     } catch (error) {
       // eslint-disable-next-line no-console
-      console.error('[docroom] Problem restoring state from worker storage', error);
-      showError(ydoc, error);
+      const log = isExpectedPlatformEvent(error) ? console.log : console.error;
+      log('[docroom] Problem restoring state from worker storage', error);
+      if (!isExpectedPlatformEvent(error)) showError(ydoc, error);
     }
 
     if (!restored && current) {
@@ -419,8 +434,9 @@ export const persistence = {
             console.log('[docroom] Restored from da-admin', docName, docType);
           } catch (error) {
             // eslint-disable-next-line no-console
-            console.error('[docroom] Problem restoring state from da-admin', error, current);
-            showError(ydoc, error);
+            const log = isExpectedPlatformEvent(error) ? console.log : console.error;
+            log('[docroom] Problem restoring state from da-admin', error, current);
+            if (!isExpectedPlatformEvent(error)) showError(ydoc, error);
           }
         }
       }, 1000);
@@ -549,6 +565,9 @@ export const getYDoc = async (docname, conn, env, storage, timingData, gc = true
       timings.forEach((v, k) => timingData.set(k, v));
     }
   } catch (e) {
+    // Remove the connection before destroy to prevent the awareness broadcast
+    // (triggered by destroy) from calling send() → closeConn() on this conn.
+    doc.conns.delete(conn);
     // ensure to cleanup event handlers and timers
     doc.destroy();
     docs.delete(docname);
@@ -607,8 +626,9 @@ export const messageListener = (conn, doc, message) => {
     }
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.error('[docroom] messageListener - Message', err.stack, err);
-    showError(doc, err);
+    const log = isExpectedPlatformEvent(err) ? console.log : console.error;
+    log('[docroom] messageListener - Message', err.stack, err);
+    if (!isExpectedPlatformEvent(err)) showError(doc, err);
   }
 };
 
@@ -649,16 +669,19 @@ export const setupWSConnection = async (conn, docName, env, storage) => {
 
   // eslint-disable-next-line no-param-reassign
   conn.binaryType = 'arraybuffer';
+
+  // Register close listener BEFORE any async operation so cleanup always fires,
+  // even if the client disconnects while the document is still loading.
+  conn.addEventListener('close', () => {
+    const doc = docs.get(docName);
+    if (doc) closeConn(doc, conn);
+  });
+
   // get doc, initialize if it does not exist yet
   const doc = await getYDoc(docName, conn, env, storage, timingData, true);
 
   // listen and reply to events
   conn.addEventListener('message', (message) => messageListener(conn, doc, new Uint8Array(message.data)));
-
-  // Check if connection is still alive
-  conn.addEventListener('close', () => {
-    closeConn(doc, conn);
-  });
   // put the following in a variables in a block so the interval handlers don't keep in in
   // scope
   try {
@@ -677,7 +700,8 @@ export const setupWSConnection = async (conn, docName, env, storage) => {
     }
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.error('[docroom] Error while setting up WSConnection', docName, err);
+    const log = isExpectedPlatformEvent(err) ? console.log : console.error;
+    log('[docroom] Error while setting up WSConnection', docName, err);
   }
 
   return timingData;

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -33,6 +33,11 @@ export const isExpectedPlatformEvent = (err) => {
     || msg.includes('cannot access storage because object has moved to a different machine');
 };
 
+export const logError = (err, ...args) => {
+  // eslint-disable-next-line no-console
+  (isExpectedPlatformEvent(err) ? console.log : console.error)(...args);
+};
+
 // disable gc when using snapshots!
 const gcEnabled = false;
 
@@ -66,9 +71,7 @@ export const closeConn = (doc, conn) => {
         /* c8 ignore start */
       } catch (err) {
         // we can ignore an exception here, closing the connection will remove the awareness states
-        // eslint-disable-next-line no-console
-        const log = isExpectedPlatformEvent(err) ? console.log : console.error;
-        log('[docroom] Error while removing awareness states', err);
+        logError(err, '[docroom] Error while removing awareness states', err);
         /* c8 ignore end */
       }
 
@@ -82,9 +85,7 @@ export const closeConn = (doc, conn) => {
   } catch (e) {
     /* c8 ignore start */
     // we can ignore an exception here, connection will be closed anyway
-    // eslint-disable-next-line no-console
-    const log = isExpectedPlatformEvent(e) ? console.log : console.error;
-    log('[docroom] Error while closing connection', e);
+    logError(e, '[docroom] Error while closing connection', e);
     /* c8 ignore end */
   }
 };
@@ -97,9 +98,7 @@ const send = (doc, conn, m) => {
     }
     conn.send(m, (err) => err != null && closeConn(doc, conn));
   } catch (e) {
-    // eslint-disable-next-line no-console
-    const log = isExpectedPlatformEvent(e) ? console.log : console.error;
-    log('[docroom] Error while sending message', e);
+    logError(e, '[docroom] Error while sending message', e);
     closeConn(doc, conn);
   }
 };
@@ -393,9 +392,7 @@ export const persistence = {
         }
       }
     } catch (error) {
-      // eslint-disable-next-line no-console
-      const log = isExpectedPlatformEvent(error) ? console.log : console.error;
-      log('[docroom] Problem restoring state from worker storage', error);
+      logError(error, '[docroom] Problem restoring state from worker storage', error);
       if (!isExpectedPlatformEvent(error)) showError(ydoc, error);
     }
 
@@ -435,9 +432,7 @@ export const persistence = {
             // eslint-disable-next-line no-console
             console.log('[docroom] Restored from da-admin', docName, docType);
           } catch (error) {
-            // eslint-disable-next-line no-console
-            const log = isExpectedPlatformEvent(error) ? console.log : console.error;
-            log('[docroom] Problem restoring state from da-admin', error, current);
+            logError(error, '[docroom] Problem restoring state from da-admin', error, current);
             if (!isExpectedPlatformEvent(error)) showError(ydoc, error);
           }
         }
@@ -627,9 +622,7 @@ export const messageListener = (conn, doc, message) => {
         break;
     }
   } catch (err) {
-    // eslint-disable-next-line no-console
-    const log = isExpectedPlatformEvent(err) ? console.log : console.error;
-    log('[docroom] messageListener - Message', err.stack, err);
+    logError(err, '[docroom] messageListener - Message', err.stack, err);
     if (!isExpectedPlatformEvent(err)) showError(doc, err);
   }
 };
@@ -701,9 +694,7 @@ export const setupWSConnection = async (conn, docName, env, storage) => {
       send(doc, conn, encoding.toUint8Array(encoder));
     }
   } catch (err) {
-    // eslint-disable-next-line no-console
-    const log = isExpectedPlatformEvent(err) ? console.log : console.error;
-    log('[docroom] Error while setting up WSConnection', docName, err);
+    logError(err, '[docroom] Error while setting up WSConnection', docName, err);
   }
 
   return timingData;

--- a/test/edge.test.js
+++ b/test/edge.test.js
@@ -322,9 +322,18 @@ describe('Worker test suite', () => {
         headers,
         url: 'http://localhost:4711/',
       };
+
+      // fetch returns the 101 immediately — accept() is synchronous, but the
+      // addEventListener calls happen in the async setupWSConnection.
       const resp = await dr.fetch(req, {}, 306);
       assert.equal(resp.headers.get('sec-websocket-protocol'), undefined);
       assert.equal(306 /* fabricated websocket response code */, resp.status);
+
+      // accept() must have happened before the response was returned
+      assert(wspCalled.includes('accept'), 'accept must be called before returning 101');
+
+      // Wait for the async session setup to complete
+      await sleep(10);
 
       assert.equal(1, bindCalled.length);
       assert.equal('http://foo.bar/1/2/3.html', bindCalled[0].nm);
@@ -333,14 +342,15 @@ describe('Worker test suite', () => {
       assert.equal('au123', wsp1.auth);
 
       const acceptIdx = wspCalled.indexOf('accept');
-      const alMessIdx = wspCalled.indexOf('addEventListener message');
       const alClsIdx = wspCalled.indexOf('addEventListener close');
+      const alMessIdx = wspCalled.indexOf('addEventListener message');
       const clsIdx = wspCalled.indexOf('close');
 
       assert(acceptIdx >= 0);
-      assert(alMessIdx > acceptIdx);
-      assert(alClsIdx > alMessIdx);
-      assert(clsIdx > alClsIdx);
+      // close listener must be registered before message listener (early cleanup on disconnect)
+      assert(alClsIdx > acceptIdx, 'close listener registered after accept');
+      assert(alMessIdx > alClsIdx, 'message listener registered after close listener');
+      assert(clsIdx > alMessIdx, 'close called after listeners registered');
     } finally {
       DocRoom.newWebSocketPair = savedNWSP;
       persistence.bindState = savedBS;
@@ -417,16 +427,16 @@ describe('Worker test suite', () => {
     try {
       // Mock bindState to throw 404 error (simulating document deleted between auth and bindState)
       persistence.bindState = async () => {
-        // eslint-disable-next-line max-len
-        await sleep(1); // the real bindState is async and we only reset the failed doc in the promise
+        await sleep(1);
         throw new Error('unable to get resource - status: 404');
       };
 
+      const closeCalled = [];
       const wsp0 = {};
       const wsp1 = {
         accept() {},
         addEventListener() {},
-        close() {},
+        close(...args) { closeCalled.push(args); },
       };
       DocRoom.newWebSocketPair = () => [wsp0, wsp1];
 
@@ -437,19 +447,40 @@ describe('Worker test suite', () => {
       headers.set('X-collab-room', 'http://foo.bar/test.html');
       headers.set('X-auth-actions', 'read=allow,write=allow');
 
-      const req = {
-        headers,
-        url: 'http://localhost:4711/',
-      };
+      const req = { headers, url: 'http://localhost:4711/' };
 
+      // fetch returns 101 immediately; setup fails asynchronously
       const resp = await dr.fetch(req, {}, 306);
+      assert.equal(306, resp.status, 'fetch must return 101 immediately, not wait for setup');
 
-      // Should return 500 error when bindState fails
-      assert.equal(500, resp.status);
-      assert.equal('Internal Server Error', await resp.text());
+      // Wait for the async setup to fail
+      await sleep(20);
+
+      assert.equal(1, closeCalled.length, 'server socket must be closed on setup failure');
+      assert.equal(1011, closeCalled[0][0]);
     } finally {
       DocRoom.newWebSocketPair = savedNWSP;
       persistence.bindState = savedBS;
+    }
+  });
+
+  it('Test DocRoom fetch synchronous error returns 500', async () => {
+    const savedNWSP = DocRoom.newWebSocketPair;
+    try {
+      DocRoom.newWebSocketPair = () => {
+        throw new Error('pair creation failed');
+      };
+
+      const dr = new DocRoom({ storage: null }, {});
+      const headers = new Map();
+      headers.set('Upgrade', 'websocket');
+      headers.set('X-collab-room', 'http://foo.bar/test.html');
+
+      const req = { headers, url: 'http://localhost:4711/' };
+      const resp = await dr.fetch(req);
+      assert.equal(500, resp.status);
+    } finally {
+      DocRoom.newWebSocketPair = savedNWSP;
     }
   });
 
@@ -458,19 +489,17 @@ describe('Worker test suite', () => {
     const savedBS = persistence.bindState;
 
     try {
-      // Mock bindState to throw an exception
-      persistence.bindState = async (nm, d, c) => {
-        // eslint-disable-next-line max-len
-        await sleep(1); // the real bindState is async and we only reset the failed doc in the promise
+      persistence.bindState = async () => {
+        await sleep(1);
         throw new Error('WebSocket setup error');
       };
 
-      // Mock WebSocketPair to return valid objects
+      const closeCalled = [];
       const wsp0 = {};
       const wsp1 = {
         accept() {},
         addEventListener() {},
-        close() {},
+        close(...args) { closeCalled.push(args); },
       };
       DocRoom.newWebSocketPair = () => [wsp0, wsp1];
 
@@ -481,15 +510,15 @@ describe('Worker test suite', () => {
       headers.set('Authorization', 'au123');
       headers.set('X-collab-room', 'http://foo.bar/test.html');
 
-      const req = {
-        headers,
-        url: 'http://localhost:4711/',
-      };
-      const resp = await dr.fetch(req);
+      const req = { headers, url: 'http://localhost:4711/' };
 
-      // Should return 500 error due to exception in WebSocket setup
-      assert.equal(500, resp.status);
-      assert.equal('Internal Server Error', await resp.text());
+      const resp = await dr.fetch(req, {}, 306);
+      assert.equal(306, resp.status, 'fetch must return 101 immediately');
+
+      await sleep(20);
+
+      assert.equal(1, closeCalled.length, 'server socket must be closed on setup failure');
+      assert.equal(1011, closeCalled[0][0]);
     } finally {
       DocRoom.newWebSocketPair = savedNWSP;
       persistence.bindState = savedBS;

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -17,7 +17,7 @@ import {
   aem2doc, doc2aem, doc2json, EMPTY_DOC,
 } from '@da-tools/da-parser';
 import {
-  closeConn, getYDoc, invalidateFromAdmin, messageListener, persistence,
+  closeConn, getYDoc, invalidateFromAdmin, isExpectedPlatformEvent, messageListener, persistence,
   readState, setupWSConnection, setYDoc, showError, storeState, updateHandler, WSSharedDoc,
 } from '../src/shareddoc.js';
 
@@ -1532,5 +1532,22 @@ describe('Collab Test Suite', () => {
       globalThis.setTimeout = savedSetTimeout;
       persistence.get = savedGet;
     }
+  });
+
+  it('isExpectedPlatformEvent returns true for Cloudflare deployment event', () => {
+    const err = new Error('This script has been upgraded');
+    assert.equal(true, isExpectedPlatformEvent(err));
+  });
+
+  it('isExpectedPlatformEvent returns true for DO live migration event', () => {
+    const err = new Error('cannot access storage because object has moved to a different machine');
+    assert.equal(true, isExpectedPlatformEvent(err));
+  });
+
+  it('isExpectedPlatformEvent returns false for regular errors', () => {
+    assert.equal(false, isExpectedPlatformEvent(new Error('some unexpected error')));
+    assert.equal(false, isExpectedPlatformEvent(new Error()));
+    assert.equal(false, isExpectedPlatformEvent(null));
+    assert.equal(false, isExpectedPlatformEvent(undefined));
   });
 });


### PR DESCRIPTION
## Summary

**Issues 1 & 2 — Platform events logged as errors:**
- Adds `isExpectedPlatformEvent(err)` helper in `shareddoc.js` that recognises the two known Cloudflare runtime messages:
  - `"This script has been upgraded"` (deployment rollout)
  - `"cannot access storage because object has moved to a different machine"` (DO live migration)
- All catch blocks across `shareddoc.js` and `edge.js` now use `console.log` for these instead of `console.error`, so they no longer pollute error dashboards

**Issue 5 — "unknown" outcome in Cloudflare worker trace logs:**
- Root cause: `DocRoom.fetch()` was awaiting the full document load (storage read + da-admin fetch) before returning the 101 WebSocket response. If a client disconnected mid-load, Cloudflare had no clean outcome to record.
- Fix: accept the WebSocket synchronously, return 101 immediately, then run `setupWSConnection` asynchronously via `.catch()`. Errors in setup now close the WebSocket with code 1011.
- Secondary fix: register the `close` listener in `setupWSConnection` **before** `await getYDoc()` so clients who disconnect during document load are cleaned up correctly.
- Bug fix: in `getYDoc` error path, remove the connection from `doc.conns` before `doc.destroy()` to prevent the awareness broadcast triggered by `destroy()` from calling `send()` → `closeConn()` → `conn.close()` spuriously (which would also cause a double-close with the explicit 1011 close).
- Drops the per-request timing headers that required awaiting setup (`X-4`, `X-5`, `X-7`, `X-9`); passes through the upstream timing headers (`X-1`, `X-2`) which are still available synchronously.

## Test plan

- [ ] All 86 tests pass (`npm test`)
- [ ] `isExpectedPlatformEvent returns true for Cloudflare deployment event`
- [ ] `isExpectedPlatformEvent returns true for DO live migration event`
- [ ] `isExpectedPlatformEvent returns false for regular errors`
- [ ] `Test DocRoom fetch` — verifies 101 returned before bindState completes; close listener registered before message listener
- [ ] `Test DocRoom fetch fails when document deleted after auth` — verifies 101 returned immediately; server socket closed with 1011 on async failure
- [ ] `Test DocRoom fetch WebSocket setup exception` — same
- [ ] `Test DocRoom fetch synchronous error returns 500` — verifies the outer catch still works for sync errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)