### PR TITLE
fix: skip stale da-admin reload when client pushes Y.js state after reconnect

### DIFF
--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -388,8 +388,23 @@ export const persistence = {
       // this timeout, the ydoc can get confused which may result in duplicated content.
       // eslint-disable-next-line no-console
       console.log('[docroom] Could not be restored, trying to restore from da-admin', docName);
+
+      // Snapshot the state vector before yielding. If the client sends any Y.js update
+      // before the timeout fires (e.g. an image whose FPO was replaced just before a
+      // 412-triggered reconnect cleared worker storage), the state vector will advance
+      // and we must NOT overwrite with the stale da-admin snapshot.
+      const svBefore = Y.encodeStateVector(ydoc);
+
       setTimeout(() => {
         if (ydoc === docs.get(docName)) {
+          const svAfter = Y.encodeStateVector(ydoc);
+          const clientHasUpdated = svBefore.length !== svAfter.length
+            || svBefore.some((v, i) => v !== svAfter[i]);
+          if (clientHasUpdated) {
+            // eslint-disable-next-line no-console
+            console.log('[docroom] Skipping da-admin reload: client state received', docName);
+            return;
+          }
           try {
             ydoc.transact(() => {
               if (docType === 'json') {

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -770,6 +770,78 @@ describe('Collab Test Suite', () => {
     assert.equal(testYDoc, json2DocCalled[1]);
   });
 
+  it('Test bindState skips da-admin reload when client sends Y.js update before timeout', async () => {
+    const aem2DocCalled = [];
+    const mockAem2Doc = (sc, yd) => aem2DocCalled.push(sc, yd);
+    const pss = await esmock('../src/shareddoc.js', {
+      '@da-tools/da-parser': {
+        aem2doc: mockAem2Doc,
+      },
+    });
+
+    const docName = 'http://lalala.com/ha/ha/ha.html';
+    const testYDoc = new Y.Doc();
+    testYDoc.daadmin = 'daadmin';
+    const mockConn = {
+      auth: 'myauth',
+      authActions: ['read'],
+    };
+    pss.setYDoc(docName, testYDoc);
+
+    const mockStorage = { list: () => new Map() };
+    pss.persistence.get = async (nm, au, ad) => `Get: ${nm}-${au}-${ad}`;
+    pss.persistence.update = async () => {};
+
+    await pss.persistence.bindState(docName, testYDoc, mockConn, mockStorage);
+
+    assert.equal(0, aem2DocCalled.length, 'Precondition');
+
+    // Simulate a client Y.js update arriving before the 1-second timeout fires.
+    // This represents the client pushing its authoritative state (e.g. an image
+    // whose FPO was just replaced) to a freshly reconnected DO whose storage was cleared.
+    testYDoc.transact(() => {
+      testYDoc.getMap('clientstate').set('img', 'real-url.png');
+    });
+
+    await wait(1500);
+
+    assert.equal(0, aem2DocCalled.length, 'da-admin reload should be skipped when the client sent state first');
+  });
+
+  it('Test bindState still reloads from da-admin when no client update arrives before timeout', async () => {
+    const aem2DocCalled = [];
+    const mockAem2Doc = (sc, yd) => aem2DocCalled.push(sc, yd);
+    const pss = await esmock('../src/shareddoc.js', {
+      '@da-tools/da-parser': {
+        aem2doc: mockAem2Doc,
+      },
+    });
+
+    const docName = 'http://lalala.com/ha/ha/ha2.html';
+    const testYDoc = new Y.Doc();
+    testYDoc.daadmin = 'daadmin';
+    const mockConn = {
+      auth: 'myauth',
+      authActions: ['read'],
+    };
+    pss.setYDoc(docName, testYDoc);
+
+    const mockStorage = { list: () => new Map() };
+    pss.persistence.get = async (nm, au, ad) => `Get: ${nm}-${au}-${ad}`;
+    pss.persistence.update = async () => {};
+
+    await pss.persistence.bindState(docName, testYDoc, mockConn, mockStorage);
+
+    assert.equal(0, aem2DocCalled.length, 'Precondition — reload is deferred');
+
+    // No client update fired; the timeout must proceed and restore from da-admin.
+    await wait(1500);
+
+    assert.equal(2, aem2DocCalled.length, 'da-admin reload must still run when no client state arrived');
+    assert.equal('Get: http://lalala.com/ha/ha/ha2.html-myauth-daadmin', aem2DocCalled[0]);
+    assert.equal(testYDoc, aem2DocCalled[1]);
+  });
+
   it('Test bindstate read from worker storage for doc', async () => {
     const docName = 'https://admin.da.live/source/foo/bar.html';
 


### PR DESCRIPTION
## User scenario

A user uploads several images one after another in the DA editor.  After uploading the 4th image, the real image briefly appears then reverts to the FPO/upload-icon placeholder (`/blocks/edit/img/fpo.svg`).

The same issue was reported for a single image upload by a second user.

## Root cause

The chain of events that triggers the regression:

1. The client uploads an image.  `da-live` inserts a temporary FPO placeholder, sends the file to da-admin, then replaces the FPO with the real image URL.
2. The Y.js `updateHandler` debounces (2 s, max 10 s) saving the updated doc state to da-admin.
3. **da-admin returns 412** on the debounced PUT (version conflict).  `da-collab` reacts by clearing its worker storage (`storage.deleteAll()`) and closing all WebSocket connections.
4. The client reconnects in ~85 ms.  `bindState` runs and, finding empty worker storage, fetches the current document from da-admin.  Because the 2 s debounce has not yet flushed, da-admin still holds the **stale snapshot** (image URL not yet written).
5. `bindState` schedules a 1-second deferred reload to avoid a race with Y.js sync.  After 1 s the doc is **overwritten with the stale snapshot**, replacing the real image URL with the FPO placeholder.

## Fix

Snapshot `Y.encodeStateVector(ydoc)` before the 1-second timeout.  At fire time, if the state vector has advanced (the reconnected client already pushed its authoritative Y.js state), the da-admin reload is **skipped** — the client state takes precedence over the stale snapshot.

## Related PRs
- da-live: adobe/da-live#918

## Tests
- `Test bindState skips da-admin reload when client sends Y.js update before timeout`
- `Test bindState still reloads from da-admin when no client update arrives before timeout`