### PR TITLE
feat: adopt Cloudflare WebSocket Hibernation API

### DIFF
--- a/src/edge.js
+++ b/src/edge.js
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import {
+  handleWebSocketClose, handleWebSocketMessage,
   invalidateFromAdmin, logError, setupWSConnection,
 } from './shareddoc.js';
 
@@ -310,6 +311,9 @@ export class DocRoom {
     // `env` is our environment bindings (discussed earlier).
     this.env = env;
     this.id = controller?.id?.toString() || `no-controller-${new Date().getTime()}`;
+
+    // `ctx` is the Durable Object controller, used for the Hibernation API
+    this.ctx = controller;
   }
 
   /**
@@ -389,7 +393,23 @@ export class DocRoom {
       // any way to act as a WebSocket server today.
       const [client, server] = DocRoom.newWebSocketPair();
 
-      this.handleSession(server, docName, auth, authActions);
+      // Register with CF Hibernation API: the DO can sleep between messages
+      // without losing its WebSocket connections.
+      this.ctx.acceptWebSocket(server);
+      server.serializeAttachment({ docName, auth, authActions });
+
+      server.auth = auth;
+      if (!authActions.split(',').includes('write')) {
+        // eslint-disable-next-line no-param-reassign
+        server.readOnly = true;
+      }
+
+      // eslint-disable-next-line no-console
+      console.log(`[docroom] Setting up WSConnection for ${docName} with auth(${
+        auth ? auth.substring(0, auth.indexOf(' ')) : 'none'})`);
+
+      // Kick off async document initialization; response is returned immediately.
+      this.initSession(server, docName);
 
       const reqHeaders = request.headers;
       const respheaders = new Headers({
@@ -411,31 +431,58 @@ export class DocRoom {
   }
 
   /**
-   * Implements our WebSocket-based protocol.
+   * Async document initialization, called after CF Hibernation API has accepted the WebSocket.
+   * Auth properties must already be set on webSocket before calling this.
    * @param {WebSocket} webSocket - The WebSocket connection to the client
    * @param {string} docName - The document name
-   * @param {string} auth - The authorization header
-   * @param {string} authActions
    */
-  async handleSession(webSocket, docName, auth, authActions) {
-    webSocket.accept();
-    // eslint-disable-next-line no-param-reassign
-    webSocket.auth = auth;
-    if (!authActions.split(',').includes('write')) {
-      // eslint-disable-next-line no-param-reassign
-      webSocket.readOnly = true;
-    }
-    // eslint-disable-next-line no-console
-    console.log(`[docroom] Setting up WSConnection for ${docName} with auth(${auth
-      ? auth.substring(0, auth.indexOf(' ')) : 'none'})`);
-
+  async initSession(webSocket, docName) {
     try {
-      await setupWSConnection(webSocket, docName, this.env, this.storage);
+      await setupWSConnection(webSocket, docName, this.env, this.storage, true);
     } catch (err) {
       logError(err, '[docroom] Error during session setup', docName, err);
       try {
         webSocket.close(1011, err.message);
       } catch (_) { /* already closed */ }
     }
+  }
+
+  /**
+   * CF Hibernation API: called when a message arrives on a hibernated WebSocket.
+   * Re-hydrates the Yjs session if the DO was evicted since the last message.
+   * @param {WebSocket} webSocket
+   * @param {ArrayBuffer|string} message
+   */
+  async webSocketMessage(webSocket, message) {
+    const { docName, auth, authActions } = webSocket.deserializeAttachment();
+    // eslint-disable-next-line no-param-reassign
+    webSocket.auth = auth;
+    if (!authActions.split(',').includes('write')) {
+      // eslint-disable-next-line no-param-reassign
+      webSocket.readOnly = true;
+    }
+    await handleWebSocketMessage(webSocket, docName, this.env, this.storage, message);
+  }
+
+  /**
+   * CF Hibernation API: called when a hibernated WebSocket closes.
+   * @param {WebSocket} webSocket
+   */
+  // eslint-disable-next-line class-methods-use-this
+  webSocketClose(webSocket) {
+    const { docName } = webSocket.deserializeAttachment();
+    handleWebSocketClose(webSocket, docName);
+  }
+
+  /**
+   * CF Hibernation API: called when a hibernated WebSocket encounters an error.
+   * @param {WebSocket} webSocket
+   * @param {Error} error
+   */
+  // eslint-disable-next-line class-methods-use-this
+  webSocketError(webSocket, error) {
+    logError(error, '[docroom] WebSocket error', error);
+    const { docName } = webSocket.deserializeAttachment();
+    handleWebSocketClose(webSocket, docName);
   }
 }

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -756,9 +756,11 @@ export const invalidateFromAdmin = async (docName) => {
  * @param {string} docName - The name of the document
  * @param {object} env - The durable object environment object
  * @param {TransactionalStorage} storage - The worker transactional storage object
+ * @param {boolean} hibernation - When true, skip event listener registration (CF Hibernation API
+ *   handles message/close routing via class methods instead of addEventListener).
  * @returns {Promise<void>} - The return value of this
  */
-export const setupWSConnection = async (conn, docName, env, storage) => {
+export const setupWSConnection = async (conn, docName, env, storage, hibernation = false) => {
   const timingData = new Map();
 
   // eslint-disable-next-line no-param-reassign
@@ -766,20 +768,25 @@ export const setupWSConnection = async (conn, docName, env, storage) => {
   // eslint-disable-next-line no-param-reassign
   conn.connectedAt = Date.now();
 
-  // Register close listener BEFORE any async operation so cleanup always fires,
-  // even if the client disconnects while the document is still loading.
-  conn.addEventListener('close', () => {
-    const doc = docs.get(docName);
-    if (doc) {
-      closeConn(doc, conn);
-    }
-  });
+  if (!hibernation) {
+    // Register close listener BEFORE any async operation so cleanup always fires,
+    // even if the client disconnects while the document is still loading.
+    conn.addEventListener('close', () => {
+      const doc = docs.get(docName);
+      if (doc) {
+        closeConn(doc, conn);
+      }
+    });
+  }
 
   // get doc, initialize if it does not exist yet
   const doc = await getYDoc(docName, conn, env, storage, timingData, true);
 
-  // listen and reply to events
-  conn.addEventListener('message', (message) => messageListener(conn, doc, new Uint8Array(message.data)));
+  if (!hibernation) {
+    // listen and reply to events
+    conn.addEventListener('message', (message) => messageListener(conn, doc, new Uint8Array(message.data)));
+  }
+
   // put the following in a variables in a block so the interval handlers don't keep in in
   // scope
   try {
@@ -801,4 +808,37 @@ export const setupWSConnection = async (conn, docName, env, storage) => {
   }
 
   return timingData;
+};
+
+/**
+ * Handle an incoming WebSocket message from the Cloudflare Hibernation API.
+ * Re-establishes the Yjs session if the DO was hibernated (doc not in memory).
+ * @param {WebSocket} conn - The WebSocket connection
+ * @param {string} docName - The document name
+ * @param {object} env - The durable object environment
+ * @param {TransactionalStorage} storage - The durable object storage
+ * @param {ArrayBuffer|string} message - The raw message from the WebSocket
+ */
+export const handleWebSocketMessage = async (conn, docName, env, storage, message) => {
+  let doc = docs.get(docName);
+  if (!doc) {
+    // DO was hibernated; re-establish Yjs state without re-registering event listeners
+    await setupWSConnection(conn, docName, env, storage, true);
+    doc = docs.get(docName);
+  }
+  if (doc) {
+    messageListener(conn, doc, new Uint8Array(message));
+  }
+};
+
+/**
+ * Handle a WebSocket close event from the Cloudflare Hibernation API.
+ * @param {WebSocket} conn - The WebSocket connection
+ * @param {string} docName - The document name
+ */
+export const handleWebSocketClose = (conn, docName) => {
+  const doc = docs.get(docName);
+  if (doc) {
+    closeConn(doc, conn);
+  }
 };

--- a/test/edge.test.js
+++ b/test/edge.test.js
@@ -15,6 +15,15 @@ import assert from 'node:assert';
 import defaultEdge, { DocRoom, handleApiRequest, handleErrors } from '../src/edge.js';
 import { WSSharedDoc, persistence, setYDoc } from '../src/shareddoc.js';
 
+function makeCtx(storage = null) {
+  const accepted = [];
+  return {
+    storage,
+    accepted,
+    acceptWebSocket(ws) { accepted.push(ws); },
+  };
+}
+
 async function sleep(ms) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -301,17 +310,17 @@ describe('Worker test suite', () => {
         return new Map();
       };
 
-      const wspCalled = [];
+      const attachCalled = [];
       const wsp0 = {};
       const wsp1 = {
-        accept() { wspCalled.push('accept'); },
-        addEventListener(type) { wspCalled.push(`addEventListener ${type}`); },
-        close() { wspCalled.push('close'); },
+        serializeAttachment(data) { attachCalled.push(data); },
+        close() {},
       };
       DocRoom.newWebSocketPair = () => [wsp0, wsp1];
 
       const daadmin = { blah: 1234 };
-      const dr = new DocRoom({ storage: null }, { daadmin });
+      const ctx = makeCtx(null);
+      const dr = new DocRoom(ctx, { daadmin });
       const headers = new Headers({
         Upgrade: 'websocket',
         Authorization: 'au123',
@@ -323,14 +332,22 @@ describe('Worker test suite', () => {
         url: 'http://localhost:4711/',
       };
 
-      // fetch returns the 101 immediately — accept() is synchronous, but the
-      // addEventListener calls happen in the async setupWSConnection.
+      // fetch returns 101 immediately; Hibernation API accepts the socket synchronously.
       const resp = await dr.fetch(req, {}, 306);
       assert.equal(resp.headers.get('sec-websocket-protocol'), undefined);
       assert.equal(306 /* fabricated websocket response code */, resp.status);
 
-      // accept() must have happened before the response was returned
-      assert(wspCalled.includes('accept'), 'accept must be called before returning 101');
+      // CF Hibernation API: acceptWebSocket must be called before the response is returned
+      assert.equal(1, ctx.accepted.length, 'acceptWebSocket must be called');
+      assert.equal(wsp1, ctx.accepted[0], 'acceptWebSocket called with server socket');
+
+      // serializeAttachment must carry docName and auth for hibernation recovery
+      assert.equal(1, attachCalled.length);
+      assert.equal('http://foo.bar/1/2/3.html', attachCalled[0].docName);
+      assert.equal('au123', attachCalled[0].auth);
+
+      // Auth set synchronously before initSession runs
+      assert.equal('au123', wsp1.auth);
 
       // Wait for the async session setup to complete
       await sleep(10);
@@ -338,19 +355,6 @@ describe('Worker test suite', () => {
       assert.equal(1, bindCalled.length);
       assert.equal('http://foo.bar/1/2/3.html', bindCalled[0].nm);
       assert.equal('1234', bindCalled[0].d.daadmin.blah);
-
-      assert.equal('au123', wsp1.auth);
-
-      const acceptIdx = wspCalled.indexOf('accept');
-      const alClsIdx = wspCalled.indexOf('addEventListener close');
-      const alMessIdx = wspCalled.indexOf('addEventListener message');
-      const clsIdx = wspCalled.indexOf('close');
-
-      assert(acceptIdx >= 0);
-      // close listener must be registered before message listener (early cleanup on disconnect)
-      assert(alClsIdx > acceptIdx, 'close listener registered after accept');
-      assert(alMessIdx > alClsIdx, 'message listener registered after close listener');
-      assert(clsIdx > alMessIdx, 'close called after listeners registered');
     } finally {
       DocRoom.newWebSocketPair = savedNWSP;
       persistence.bindState = savedBS;
@@ -366,14 +370,13 @@ describe('Worker test suite', () => {
 
       const wsp0 = {};
       const wsp1 = {
-        accept() { },
-        addEventListener(type) { },
-        close() { },
+        serializeAttachment() {},
+        close() {},
       };
       DocRoom.newWebSocketPair = () => [wsp0, wsp1];
 
       const daadmin = { blah: 1234 };
-      const dr = new DocRoom({ storage: null }, { daadmin });
+      const dr = new DocRoom(makeCtx(null), { daadmin });
       const headers = new Headers({
         Upgrade: 'websocket',
         Authorization: 'au123',
@@ -437,14 +440,13 @@ describe('Worker test suite', () => {
       const closeCalled = [];
       const wsp0 = {};
       const wsp1 = {
-        accept() {},
-        addEventListener() {},
+        serializeAttachment() {},
         close(...args) { closeCalled.push(args); },
       };
       DocRoom.newWebSocketPair = () => [wsp0, wsp1];
 
       const daadmin = { fetch: async () => ({ ok: true }) };
-      const dr = new DocRoom({ storage: null }, { daadmin });
+      const dr = new DocRoom(makeCtx(null), { daadmin });
       const headers = new Map();
       headers.set('Upgrade', 'websocket');
       headers.set('X-collab-room', 'http://foo.bar/test.html');
@@ -500,14 +502,13 @@ describe('Worker test suite', () => {
       const closeCalled = [];
       const wsp0 = {};
       const wsp1 = {
-        accept() {},
-        addEventListener() {},
+        serializeAttachment() {},
         close(...args) { closeCalled.push(args); },
       };
       DocRoom.newWebSocketPair = () => [wsp0, wsp1];
 
       const daadmin = { test: 'value' };
-      const dr = new DocRoom({ storage: null }, { daadmin });
+      const dr = new DocRoom(makeCtx(null), { daadmin });
       const headers = new Map();
       headers.set('Upgrade', 'websocket');
       headers.set('Authorization', 'au123');
@@ -1023,5 +1024,175 @@ describe('Worker test suite', () => {
     const json = await res.json();
     assert.equal('ok', json.status);
     assert.deepStrictEqual(['da-admin'], json.service_bindings);
+  });
+
+  it('Test DocRoom webSocketMessage restores auth and processes message (cold start)', async () => {
+    const savedBS = persistence.bindState;
+    try {
+      const bindCalled = [];
+      persistence.bindState = async (nm, d, c) => {
+        bindCalled.push({ nm, c });
+        return new Map();
+      };
+
+      const docName = 'http://foo.bar/cold-start.html';
+      // Doc is NOT in the map — simulates hibernation eviction
+
+      const closeCalled = [];
+      const mockConn = {
+        auth: undefined,
+        readOnly: undefined,
+        binaryType: undefined,
+        readyState: 1,
+        send() {},
+        close() { closeCalled.push('close'); },
+        deserializeAttachment() {
+          // authActions format: comma-separated values extracted after '=' from X-da-actions header
+          return { docName, auth: 'Bearer session-token', authActions: 'read,write' };
+        },
+      };
+
+      const dr = new DocRoom(makeCtx({}), { daadmin: {} });
+      const msg = new Uint8Array([0, 0]).buffer; // minimal message
+
+      await dr.webSocketMessage(mockConn, msg);
+
+      // Auth must be restored from the serialized attachment
+      assert.equal('Bearer session-token', mockConn.auth);
+      assert.equal(undefined, mockConn.readOnly); // write is in authActions
+      // Doc should have been initialized (bindState called)
+      assert.equal(1, bindCalled.length);
+      assert.equal(docName, bindCalled[0].nm);
+    } finally {
+      persistence.bindState = savedBS;
+    }
+  });
+
+  it('Test DocRoom webSocketMessage warm start (doc already in memory)', async () => {
+    const savedBS = persistence.bindState;
+    try {
+      const bindCalled = [];
+      persistence.bindState = async (nm) => {
+        bindCalled.push(nm);
+        return new Map();
+      };
+
+      const docName = 'http://foo.bar/warm-start.html';
+      const testYdoc = new WSSharedDoc(docName);
+      const mockConn = {
+        auth: undefined,
+        binaryType: undefined,
+        readyState: 1,
+        send() {},
+        close() {},
+        deserializeAttachment() {
+          return { docName, auth: 'Bearer warm-token', authActions: 'write' };
+        },
+      };
+      testYdoc.conns.set(mockConn, new Set());
+      setYDoc(docName, testYdoc);
+
+      try {
+        const dr = new DocRoom(makeCtx({}), { daadmin: {} });
+        const msg = new Uint8Array([0]).buffer;
+        await dr.webSocketMessage(mockConn, msg);
+
+        assert.equal('Bearer warm-token', mockConn.auth);
+        // Doc was in memory — bindState must NOT be called again
+        assert.equal(0, bindCalled.length);
+      } finally {
+        testYdoc.destroy();
+      }
+    } finally {
+      persistence.bindState = savedBS;
+    }
+  });
+
+  it('Test DocRoom webSocketClose cleans up connection', async () => {
+    const docName = 'http://foo.bar/ws-close.html';
+    const testYdoc = new WSSharedDoc(docName);
+
+    const closeCalled = [];
+    const mockConn = {
+      close() { closeCalled.push('close'); },
+      deserializeAttachment() {
+        return { docName, auth: 'test-auth', authActions: 'write=allow' };
+      },
+    };
+    testYdoc.conns.set(mockConn, new Set());
+    const m = setYDoc(docName, testYdoc);
+
+    const dr = new DocRoom(makeCtx(null), {});
+    dr.webSocketClose(mockConn, 1000, 'Normal', true);
+
+    assert.deepStrictEqual(['close'], closeCalled);
+    assert(!m.has(docName), 'Doc should be removed when no connections remain');
+
+    testYdoc.destroy();
+  });
+
+  it('Test DocRoom webSocketError logs and cleans up connection', async () => {
+    const docName = 'http://foo.bar/ws-error.html';
+    const testYdoc = new WSSharedDoc(docName);
+
+    const closeCalled = [];
+    const mockConn = {
+      close() { closeCalled.push('close'); },
+      deserializeAttachment() {
+        return { docName, auth: undefined, authActions: '' };
+      },
+    };
+    testYdoc.conns.set(mockConn, new Set());
+    const m = setYDoc(docName, testYdoc);
+
+    const dr = new DocRoom(makeCtx(null), {});
+    dr.webSocketError(mockConn, new Error('connection reset'));
+
+    assert.deepStrictEqual(['close'], closeCalled);
+    assert(!m.has(docName), 'Doc should be removed on error');
+
+    testYdoc.destroy();
+  });
+
+  it('Test DocRoom webSocketClose no-op when doc not in memory', async () => {
+    const mockConn = {
+      close() { assert.fail('close must not be called when doc is not in memory'); },
+      deserializeAttachment() {
+        return { docName: 'http://foo.bar/gone.html', auth: undefined, authActions: '' };
+      },
+    };
+
+    const dr = new DocRoom(makeCtx(null), {});
+    dr.webSocketClose(mockConn, 1000, 'Normal', true);
+    // No assertion needed — test passes if close() is not called
+  });
+
+  it('Test DocRoom webSocketMessage read-only auth restored', async () => {
+    const savedBS = persistence.bindState;
+    try {
+      persistence.bindState = async () => new Map();
+
+      const docName = 'http://foo.bar/readonly.html';
+      const mockConn = {
+        auth: undefined,
+        readOnly: undefined,
+        binaryType: undefined,
+        readyState: 1,
+        send() {},
+        close() {},
+        deserializeAttachment() {
+          // authActions without 'write' — should be read-only
+          return { docName, auth: 'Bearer ro-token', authActions: 'read' };
+        },
+      };
+
+      const dr = new DocRoom(makeCtx({}), { daadmin: {} });
+      await dr.webSocketMessage(mockConn, new Uint8Array([0]).buffer);
+
+      assert.equal('Bearer ro-token', mockConn.auth);
+      assert.equal(true, mockConn.readOnly);
+    } finally {
+      persistence.bindState = savedBS;
+    }
   });
 });


### PR DESCRIPTION
## Problem

During image drag-and-drop sessions in DA, Durable Objects are evicted when the browser briefly drops WebSockets (while busy uploading blobs). Each eviction clears the in-memory `docs` Map. On reconnect, `bindState` re-fetches from da-admin and triggers a 1-second revert timer, causing the just-inserted images to disappear.

## Root cause

`webSocket.accept()` (the non-Hibernation API) causes the DO to be evicted whenever a WebSocket disconnects. Any work in flight (debounced saves, `bindState` async chain) is cancelled with `Outcome: "canceled"`, and the in-memory Yjs state is lost.

## Solution

Adopt the **Cloudflare WebSocket Hibernation API** (`ctx.acceptWebSocket()`), which keeps the DO alive across WebSocket disconnects:

- `DocRoom.fetch()` calls `this.ctx.acceptWebSocket(server)` + `server.serializeAttachment({ docName, auth, authActions })` instead of `server.accept()`
- New class methods `webSocketMessage`, `webSocketClose`, `webSocketError` handle CF Hibernation routing
- `setupWSConnection` gains a `hibernation` flag (default `false`) — when `true`, skips `addEventListener` registration since CF calls the class methods directly
- New exports `handleWebSocketMessage` and `handleWebSocketClose` in `shareddoc.js` allow `webSocketMessage`/`webSocketClose` to re-hydrate Yjs state after a cold start

## Tests

- Updated 4 existing WebSocket tests to use `ctx.acceptWebSocket` mock + `serializeAttachment`
- Added 6 new tests: cold-start re-hydration, warm-start (no redundant `bindState`), `webSocketClose` cleanup, `webSocketError` cleanup, no-op close on unknown doc, read-only auth restoration

🤖 Generated with [Claude Code](https://claude.com/claude-code)