### PR TITLE
fix: always trust worker storage over stale da-admin on DO rehydration

### DIFF
--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -389,16 +389,14 @@ export const persistence = {
       if (stored && stored.length > 0) {
         Y.applyUpdate(ydoc, stored);
 
-        // Check if the state from the worker storage is the same as the current state in da-admin.
-        // So for example if da-admin doesn't have the doc any more, or if it has been altered in
-        // another way, we don't use the state of the worker storage.
-        const fromStorage = docType === 'json' ? doc2json(ydoc) : doc2aem(ydoc);
-        if (fromStorage === current) {
-          restored = true;
+        // Worker storage holds the most-recent Yjs state, including edits that have not yet
+        // been flushed to da-admin (e.g. because the debounced PUT was still in flight when the
+        // DO was evicted). Always trust storage over da-admin; the syncadmin/deleteadmin APIs
+        // are responsible for clearing stale storage when da-admin is modified externally.
+        restored = true;
 
-          // eslint-disable-next-line no-console
-          console.log('[docroom] Restored from worker persistence', docName);
-        }
+        // eslint-disable-next-line no-console
+        console.log('[docroom] Restored from worker persistence', docName);
       }
     } catch (error) {
       logError(error, '[docroom] Problem restoring state from worker storage', error);

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -940,6 +940,69 @@ describe('Collab Test Suite', () => {
     }
   });
 
+  it('Test bindstate trusts storage when storage is newer than da-admin', async () => {
+    // Scenario: user added a new paragraph; PUT to da-admin failed (debounce/412).
+    // Worker storage has the new paragraph; da-admin doesn't.
+    // bindState must preserve the storage content, NOT overwrite with stale da-admin.
+    const docName = 'https://admin.da.live/source/foo/newer.html';
+
+    const daadminContent = `
+<body>
+  <header></header>
+  <main><div><p>First paragraph</p></div></main>
+  <footer></footer>
+</body>`;
+
+    const storageContent = `
+<body>
+  <header></header>
+  <main><div><p>First paragraph</p><p>Second paragraph added later</p></div></main>
+  <footer></footer>
+</body>`;
+
+    // Build Yjs storage bytes from storageContent
+    const storageDoc = new Y.Doc();
+    aem2doc(storageContent, storageDoc);
+    const storedYDoc = Y.encodeStateAsUpdate(storageDoc);
+    const stored = new Map();
+    stored.set('docstore', storedYDoc);
+    stored.set('doc', docName);
+
+    const ydoc = new Y.Doc();
+    setYDoc(docName, ydoc);
+
+    const storage = { list: async () => stored };
+
+    const savedGet = persistence.get;
+    const savedSetTimeout = globalThis.setTimeout;
+    try {
+      persistence.get = async () => daadminContent;
+
+      let timerCallback;
+      globalThis.setTimeout = (f) => {
+        timerCallback = f; // capture but do not run yet
+      };
+
+      await persistence.bindState(docName, ydoc, {}, storage);
+
+      // Storage content must be in ydoc immediately after bind
+      assert(doc2aem(ydoc).includes('Second paragraph added later'), 'ydoc must contain storage content after bind');
+
+      // Timer must NOT be registered when storage is authoritative
+      assert(!timerCallback, 'da-admin reload timer must not be registered when storage is newer');
+
+      // Belt-and-suspenders: even if the timer fires (old behaviour), content must survive
+      if (timerCallback) {
+        await timerCallback();
+        assert(doc2aem(ydoc).includes('Second paragraph added later'), 'storage content must survive timer');
+      }
+    } finally {
+      persistence.get = savedGet;
+      globalThis.setTimeout = savedSetTimeout;
+      ydoc.destroy();
+    }
+  });
+
   it('Test bindstate falls back to daadmin on worker storage error', async () => {
     const docName = 'https://admin.da.live/source/foo/bar.html';
     const ydoc = new Y.Doc();


### PR DESCRIPTION
## Problem

When a Durable Object is evicted (e.g. during an image upload that briefly drops the WebSocket), `bindState` refetches the document from da-admin and compares `fromStorage === current`. This comparison fails whenever worker storage holds edits that have not yet been flushed to da-admin (debounced PUT still in flight). The mismatch sets `restored = false`, fires the 1-second reload timer, and overwrites the Yjs document with the stale da-admin snapshot — causing recently-inserted images to disappear.

## Root cause

The `fromStorage === current` string comparison was meant to detect "da-admin was externally modified while the DO was sleeping." In practice it fires in the **normal case**: any edit that hasn't been saved to da-admin yet will produce `fromStorage !== current`, triggering the destructive reload.

## Solution

Remove the string comparison and always set `restored = true` when valid storage exists.

**Why this is safe:** Worker storage is updated synchronously on every Yjs transaction (via the `update` listener) and therefore always holds the most-recent collaborative state — potentially newer than da-admin. The `syncadmin` and `deleteadmin` admin APIs are the correct mechanism for clearing stale storage when da-admin is modified externally.

## Tests

Added: *Test bindstate trusts storage when storage is newer than da-admin* — verifies that the reload timer is NOT registered when storage contains edits not yet in da-admin, and that the storage content survives without being overwritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)