### PR TITLE
chore: fix dry run

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,20 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
+      - name: Validate GITHUB_TOKEN
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/user)
+          echo "GitHub API status: $STATUS"
+          [ "$STATUS" = "200" ] && echo "Token is valid" || echo "Token is invalid or expired"
+      - name: Validate ADOBE_BOT_GITHUB_TOKEN
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer ${{ secrets.ADOBE_BOT_GITHUB_TOKEN }}" \
+            https://api.github.com/user)
+          echo "GitHub API status: $STATUS"
+          [ "$STATUS" = "200" ] && echo "Token is valid" || echo "Token is invalid or expired"
       - name: Checkout repository
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,6 +46,9 @@ jobs:
     needs: test
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: true
+          token: ${{ secrets.ADOBE_BOT_GITHUB_TOKEN }}
       - name: Use Node.js 24.x
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.ADOBE_BOT_GITHUB_TOKEN }}
       - name: Set up Node.js 24.x
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
Missing valid `GITHUB_TOKEN` during `Semantic Release (Dry Run)` step.