### PR TITLE
fix: guard persistence.put against empty-stub overwrites (COR-31)

### DIFF
--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -48,6 +48,11 @@ const messageSync = 0;
 const messageAwareness = 1;
 const MAX_STORAGE_KEYS = 128;
 const MAX_STORAGE_VALUE_SIZE = 131072;
+// Matches da-admin EMPTY_DOC_SIZE — the byte-length of doc2aem(empty ydoc).
+// PUTs at or below this size are the deterministic empty stub; allowing one
+// through when no client edit happened silently overwrites real customer content
+// (and triggers da-admin's Restore Point fallback).
+const EMPTY_DOC_SIZE = 83;
 
 function getDocType(docName) {
   if (docName.endsWith('.json')) return 'json';
@@ -287,9 +292,9 @@ export const persistence = {
 
     opts.headers = new Headers(headers);
 
-    if (blob.size < 84) {
+    if (blob.size <= EMPTY_DOC_SIZE) {
       // eslint-disable-next-line no-console
-      console.warn('[docroom] Writting back an empty document', ydoc.name, blob.size);
+      console.warn('[docroom] Writing back an empty document', ydoc.name, blob.size);
     }
 
     const {
@@ -320,6 +325,17 @@ export const persistence = {
     let closeAll = false;
     try {
       const content = docType === 'json' ? doc2json(ydoc) : doc2aem(ydoc);
+
+      // Never overwrite real content with the deterministic empty stub when no
+      // client edit produced it. Defends customer content against COR-31:
+      // bindState fallbacks, awareness/storage-only updates, or transient
+      // server-side transacts can otherwise debounce a stub PUT through.
+      if (!ydoc.hasClientChanged && content.length <= EMPTY_DOC_SIZE) {
+        // eslint-disable-next-line no-console
+        console.log('[docroom] Skipping empty-stub PUT - no client edit', docName, content.length);
+        return current;
+      }
+
       if (current !== content) {
         // Only store the document if it was actually changed.
         const { ok, status, statusText } = await persistence.put(ydoc, content);
@@ -517,6 +533,9 @@ export class WSSharedDoc extends Y.Doc {
     super({ gc: gcEnabled });
     this.name = name;
     this.conns = new Map();
+    // Flipped by messageListener whenever a sync message advances the state
+    // vector. Gates the empty-stub PUT guard in persistence.update — see COR-31.
+    this.hasClientChanged = false;
     this.awareness = new awarenessProtocol.Awareness(this);
     this.awareness.setLocalState(null);
 
@@ -636,9 +655,15 @@ export const messageListener = (conn, doc, message) => {
     const decoder = decoding.createDecoder(message);
     messageType = decoding.readVarUint(decoder);
     switch (messageType) {
-      case messageSync:
+      case messageSync: {
         encoding.writeVarUint(encoder, messageSync);
+        const svBefore = Y.encodeStateVector(doc);
         readSyncMessage(decoder, encoder, doc, conn.readOnly);
+        const svAfter = Y.encodeStateVector(doc);
+        if (svBefore.length !== svAfter.length
+          || svBefore.some((v, i) => v !== svAfter[i])) {
+          doc.hasClientChanged = true;
+        }
 
         // If the `encoder` only contains the type of reply message and no
         // message, there is no need to send the message. When `encoder` only
@@ -647,6 +672,7 @@ export const messageListener = (conn, doc, message) => {
           send(doc, conn, encoding.toUint8Array(encoder));
         }
         break;
+      }
       case messageAwareness: {
         awarenessProtocol
           .applyAwarenessUpdate(doc.awareness, decoding.readVarUint8Array(decoder), conn);

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -657,13 +657,12 @@ export const messageListener = (conn, doc, message) => {
     switch (messageType) {
       case messageSync: {
         encoding.writeVarUint(encoder, messageSync);
-        const svBefore = Y.encodeStateVector(doc);
-        readSyncMessage(decoder, encoder, doc, conn.readOnly);
-        const svAfter = Y.encodeStateVector(doc);
-        if (svBefore.length !== svAfter.length
-          || svBefore.some((v, i) => v !== svAfter[i])) {
+        const onChange = () => {
           doc.hasClientChanged = true;
-        }
+        };
+        doc.on('update', onChange);
+        readSyncMessage(decoder, encoder, doc, conn.readOnly);
+        doc.off('update', onChange);
 
         // If the `encoder` only contains the type of reply message and no
         // message, there is no need to send the message. When `encoder` only

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -10,6 +10,8 @@
  * governing permissions and limitations under the License.
  */
 import * as Y from 'yjs';
+import * as syncProtocol from 'y-protocols/sync.js';
+import * as encoding from 'lib0/encoding.js';
 import assert from 'node:assert';
 import esmock from 'esmock';
 
@@ -357,6 +359,7 @@ describe('Collab Test Suite', () => {
     const mockYDoc = {
       conns: { keys() { return [{}]; } },
       name: 'http://foo.bar/0/123.html',
+      hasClientChanged: true,
     };
 
     let called = false;
@@ -389,6 +392,7 @@ describe('Collab Test Suite', () => {
     const mockYDoc = {
       conns: new Map().set('foo', 'bar'),
       name: 'http://foo.bar/0/123.html',
+      hasClientChanged: true,
       getMap(nm) { return nm === 'error' ? new Map() : null; },
       transact: (f) => f(),
     };
@@ -417,6 +421,100 @@ describe('Collab Test Suite', () => {
   it('Test persistence update closes all on auth failure', async () => {
     await testCloseAllOnAuthFailure(401);
     await testCloseAllOnAuthFailure(403);
+  });
+
+  it('Test persistence update skips PUT when content is empty stub and no client edit', async () => {
+    // Reproduces COR-31 / COR-28: an unedited ydoc whose doc2aem output is the
+    // deterministic empty stub must NOT overwrite real content in da-admin.
+    const EMPTY_STUB = '\n<body>\n  <header></header>\n  <main><div></div></main>\n  <footer></footer>\n</body>\n';
+    const mockDoc2Aem = () => EMPTY_STUB;
+    const pss = await esmock('../src/shareddoc.js', {
+      '@da-tools/da-parser': {
+        doc2aem: mockDoc2Aem,
+      },
+    });
+
+    const mockYDoc = {
+      conns: { keys() { return [{}]; } },
+      name: 'http://foo.bar/0/123.html',
+      hasClientChanged: false,
+    };
+
+    let putCalled = false;
+    pss.persistence.put = async () => {
+      putCalled = true;
+      return { ok: true, status: 200 };
+    };
+
+    const real = '<body><main><div><p>real customer content</p></div></main></body>';
+    const result = await pss.persistence.update(mockYDoc, real, 'test.html');
+    assert.equal(false, putCalled, 'Empty stub PUT must be blocked when no client edit produced it');
+    assert.equal(result, real, 'Returns current unchanged when guard blocks the PUT');
+  });
+
+  it('Test persistence update still PUTs empty content when client edit produced it', async () => {
+    // Defence-in-depth: the guard must not block legitimate empty writes
+    // (e.g. user deletes all content) when hasClientChanged is true.
+    const EMPTY_STUB = '\n<body>\n  <header></header>\n  <main><div></div></main>\n  <footer></footer>\n</body>\n';
+    const mockDoc2Aem = () => EMPTY_STUB;
+    const pss = await esmock('../src/shareddoc.js', {
+      '@da-tools/da-parser': {
+        doc2aem: mockDoc2Aem,
+      },
+    });
+
+    const mockYDoc = {
+      conns: { keys() { return [{}]; } },
+      name: 'http://foo.bar/0/123.html',
+      hasClientChanged: true,
+    };
+
+    const putCalls = [];
+    pss.persistence.put = async (yd, c) => {
+      putCalls.push(c);
+      return { ok: true, status: 200 };
+    };
+
+    const result = await pss.persistence.update(mockYDoc, '<main><div><p>old</p></div></main>', 'test.html');
+    assert.equal(1, putCalls.length, 'PUT must run when client really emptied the doc');
+    assert.equal(putCalls[0], EMPTY_STUB);
+    assert.equal(result, EMPTY_STUB);
+  });
+
+  it('Test messageListener flips hasClientChanged on non-no-op sync update', () => {
+    const ydoc = new WSSharedDoc('test.html');
+    assert.equal(false, ydoc.hasClientChanged, 'Precondition: starts false');
+
+    // Donor doc to encode an authoritative update from
+    const donor = new Y.Doc();
+    donor.getMap('content').set('foo', 'bar');
+    const update = Y.encodeStateAsUpdate(donor);
+
+    const encoder = encoding.createEncoder();
+    encoding.writeVarUint(encoder, 0); // messageSync
+    syncProtocol.writeUpdate(encoder, update);
+    const message = encoding.toUint8Array(encoder);
+
+    const conn = { readyState: 1, send: () => {} };
+    messageListener(conn, ydoc, message);
+
+    assert.equal(true, ydoc.hasClientChanged, 'Non-no-op sync update must flip the flag');
+  });
+
+  it('Test messageListener does NOT flip hasClientChanged on no-op sync (step 1)', () => {
+    const ydoc = new WSSharedDoc('test.html');
+    assert.equal(false, ydoc.hasClientChanged, 'Precondition: starts false');
+
+    // Sync step 1 only writes a reply; it does NOT mutate the receiving doc.
+    const encoder = encoding.createEncoder();
+    encoding.writeVarUint(encoder, 0); // messageSync
+    syncProtocol.writeSyncStep1(encoder, ydoc);
+    const message = encoding.toUint8Array(encoder);
+
+    const conn = { readyState: 1, send: () => {} };
+    messageListener(conn, ydoc, message);
+
+    assert.equal(false, ydoc.hasClientChanged, 'Sync step 1 (no doc mutation) must not flip the flag');
   });
 
   it('Test persistence update closes all and cleans storage on 412', async () => {


### PR DESCRIPTION
## Summary

- Stops da-collab from PUTting the deterministic 83-byte AEM empty stub back to da-admin when no real client edit happened (`hasClientChanged === false`).
- New `WSSharedDoc.hasClientChanged` flag is flipped only when a sync message advances `Y.encodeStateVector(doc)`, so server-side `aem2doc` transacts inside `bindState` and storage-only updates can no longer trigger an empty PUT.
- Adds `EMPTY_DOC_SIZE = 83` to mirror da-admin's threshold (`da-admin/src/utils/constants.js`); aligns the existing `Writting back an empty document` warn condition to use the same constant and fixes the typo (per the COR-28 out-of-scope note).
- da-admin's Restore Point machinery is preserved as defence-in-depth — this change just stops da-collab from ever sending the stub in the first place.

Context: COR-31 (linked) — investigation in COR-28 showed ~110 empty-doc warns/24h translating into ~226 unique customer documents/day silently being reset to the empty stub.

## Test plan

- [x] `npm test` — 98 tests pass, coverage 100% statements / 100% lines for the touched module (`src/shareddoc.js`).
- [x] `npm run lint` — 0 errors (2 pre-existing warnings in `test/edge.test.js`, untouched).
- [x] New TDD tests:
  - skips PUT when content is the empty stub and no client edit happened
  - still PUTs empty content when `hasClientChanged === true` (regression / defence-in-depth)
  - `messageListener` flips `hasClientChanged` on a non-no-op sync update
  - `messageListener` does NOT flip `hasClientChanged` on a no-op sync (step 1)
- [ ] Coralogix sanity check post-deploy: `'Writing back an empty document'` count should drop to ~baseline (≤20/24h); paired `Empty body, creating a restore point` in da-admin should drop in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)