### PR TITLE
fix(docroom): include docName in update-failure log

### DIFF
--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -346,7 +346,7 @@ export const persistence = {
       }
     } catch (err) {
       // eslint-disable-next-line no-console
-      console.error('[docroom] Failed to update document', err);
+      console.error('[docroom] Failed to update document', docName, err);
       showError(ydoc, err);
     }
     if (closeAll) {


### PR DESCRIPTION
## Summary

- Add `docName` to the `[docroom] Failed to update document` error log in `src/shareddoc.js:349`.
- Matches the existing convention at lines 189 and 473.

## Why

The 9/24h `Expected value of type string,null for attribute alt on type image` failures (from doc2aem) currently log without the document name, so DataPrime cannot pair the URL with the post-explode log row. Adding `docName` unblocks the COR-27 follow-up audit.

## Test plan

- [x] `npm run lint` — clean for the touched file (pre-existing warnings in `test/edge.test.js` only).
- [x] `npm test` — all 94 tests pass; 100% line coverage on `shareddoc.js`.
- [ ] Post-deploy: confirm DataPrime can extract `docname` from the new log row.

## Scope

One line. No surrounding-logic changes; no promotion to `logError` (per the issue brief, this is not an expected platform event).

## References

- Parent: COR-27
- Source: `src/shareddoc.js:349`

Co-Authored-By: Paperclip <noreply@paperclip.ing>