### PR TITLE
fix(docroom): include docName in da-admin restore failure log

### DIFF
--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -456,7 +456,7 @@ export const persistence = {
             // eslint-disable-next-line no-console
             console.log('[docroom] Restored from da-admin', docName, docType);
           } catch (error) {
-            logError(error, '[docroom] Problem restoring state from da-admin', error, current);
+            logError(error, '[docroom] Problem restoring state from da-admin', docName, error, current);
             if (!isExpectedPlatformEvent(error)) showError(ydoc, error);
           }
         }

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -870,6 +870,46 @@ describe('Collab Test Suite', () => {
     assert.equal(testYDoc, aem2DocCalled[1]);
   });
 
+  it('Test bindState includes docName when aem2doc throws while restoring from da-admin', async () => {
+    const throwing = () => {
+      throw new TypeError("Cannot read properties of undefined (reading 'toLowerCase')");
+    };
+    const pss = await esmock('../src/shareddoc.js', {
+      '@da-tools/da-parser': {
+        aem2doc: throwing,
+      },
+    });
+
+    const docName = 'http://lalala.com/ha/ha/failing.html';
+    const testYDoc = new Y.Doc();
+    testYDoc.daadmin = 'daadmin';
+    const mockConn = {
+      auth: 'myauth',
+      authActions: ['read'],
+    };
+    pss.setYDoc(docName, testYDoc);
+
+    const mockStorage = { list: () => new Map() };
+    pss.persistence.get = async (nm, au, ad) => `Get: ${nm}-${au}-${ad}`;
+    pss.persistence.update = async () => {};
+
+    const logged = [];
+    const savedError = console.error;
+    console.error = (...args) => logged.push(args);
+    try {
+      await pss.persistence.bindState(docName, testYDoc, mockConn, mockStorage);
+      // Wait for the 1s deferred reload + a buffer.
+      await wait(1500);
+    } finally {
+      console.error = savedError;
+    }
+
+    const daAdminLogs = logged.filter((args) => args[0] === '[docroom] Problem restoring state from da-admin');
+    assert.equal(1, daAdminLogs.length, 'da-admin restore failure should be logged exactly once');
+    assert.equal(docName, daAdminLogs[0][1], 'docName must appear in the da-admin restore failure log (Coralogix uses it to identify the failing doc)');
+    assert(daAdminLogs[0][2] instanceof TypeError, 'the underlying error must still be logged for stack capture');
+  });
+
   it('Test bindstate read from worker storage for doc', async () => {
     const docName = 'https://admin.da.live/source/foo/bar.html';
 


### PR DESCRIPTION
## Summary

When `aem2doc` / `json2doc` throws while restoring state from da-admin after a reconnect, the failure log currently carries the error and the raw HTML content but **not** the document name, so the daily DataPrime review cannot pair the 3/24h `Cannot read properties of undefined (reading 'toLowerCase')` rows with the affected docs.

This adds `docName` to the `logError` call at `src/shareddoc.js:459`, mirroring the COR-29 update-failure pattern (PR #143).

- Refs: COR-33 (sibling of COR-27/COR-30; reverse parsing direction — `aem2doc`, not `doc2aem`)
- Impact: future Coralogix rows will identify the failing doc so we can capture a sample and reproduce the TypeError inside `@da-tools/da-parser`.

## Why not also fix the parser here

We don't yet know the exact shape that breaks `aem2doc` — `toLowerCase` on undefined could be `tagName`, `attrName`, `nodeName`, or similar, and the failure rate is 3/24h. Adding `docName` to the log is the prerequisite to identify a real failing doc; once captured, the parser-side defensive fix lands in a follow-up against `@da-tools/da-parser` and stays out of scope for da-collab.

## Test plan

- [x] New unit test `Test bindState includes docName when aem2doc throws while restoring from da-admin` — mocks `aem2doc` to throw the production TypeError, asserts `console.error` receives both the log key and `docName`, and that the underlying error object is still passed for stack capture.
- [x] `npx mocha -g "bindState"` — 5 passing.
- [x] `npx mocha -g "bindstate|bindState|daadmin|invalidate"` — 10 passing.
- [x] `npx eslint src/shareddoc.js test/shareddoc.test.js` — clean.

## Out of scope

- Parser-side defensive normalization in `aem2doc` (lands in `@da-tools/da-parser` once we capture a failing doc).
- The `doc2aem` direction (COR-30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)