### PR TITLE
feat: add targeted session logging to diagnose content-loss

### DIFF
--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -81,7 +81,9 @@ export const closeConn = (doc, conn) => {
       }
 
       if (doc.conns.size === 0) {
-        // clear event handlers
+        const duration = conn.connectedAt ? Date.now() - conn.connectedAt : 0;
+        // eslint-disable-next-line no-console
+        console.log('[docroom] Last connection closed', doc.name, `duration: ${duration}ms`, `unsaved: ${!!doc.isDirty}`);
         doc.destroy();
         docs.delete(doc.name);
       }
@@ -358,6 +360,8 @@ export const persistence = {
           throw new Error(`${status} - ${statusText}`);
         }
 
+        // eslint-disable-next-line no-console
+        console.log('[docroom] Saved to da-admin', docName, `${content.length}b`);
         return content;
       }
     } catch (err) {
@@ -481,6 +485,8 @@ export const persistence = {
 
     ydoc.on('update', async () => {
       // Whenever we receive an update on the document store it in the local storage
+      // eslint-disable-next-line no-param-reassign
+      ydoc.isDirty = true;
       if (ydoc === docs.get(docName)) { // make sure this ydoc is still active
         try {
           await storeState(docName, Y.encodeStateAsUpdate(ydoc), storage);
@@ -495,10 +501,17 @@ export const persistence = {
     ydoc.on('update', debounce(async () => {
       // If we receive an update on the document, store it in da-admin, but debounce it
       // to avoid excessive da-admin calls.
-      if (saving || !current || ydoc !== docs.get(docName)) return;
+      if (saving) {
+        // eslint-disable-next-line no-console
+        console.log('[docroom] Skip save: concurrent save in progress', docName);
+        return;
+      }
+      if (!current || ydoc !== docs.get(docName)) return;
       saving = true;
       try {
         current = await persistence.update(ydoc, current, docName);
+        // eslint-disable-next-line no-param-reassign
+        ydoc.isDirty = false;
       } finally {
         saving = false;
       }
@@ -723,6 +736,8 @@ export const setupWSConnection = async (conn, docName, env, storage) => {
 
   // eslint-disable-next-line no-param-reassign
   conn.binaryType = 'arraybuffer';
+  // eslint-disable-next-line no-param-reassign
+  conn.connectedAt = Date.now();
 
   // Register close listener BEFORE any async operation so cleanup always fires,
   // even if the client disconnects while the document is still loading.

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -83,7 +83,7 @@ export const closeConn = (doc, conn) => {
       if (doc.conns.size === 0) {
         const duration = conn.connectedAt ? Date.now() - conn.connectedAt : 0;
         // eslint-disable-next-line no-console
-        console.log('[docroom] Last connection closed', doc.name, `duration: ${duration}ms`, `unsaved: ${!!doc.isDirty}`);
+        console.log('[docroom] Last connection closed', doc.name, `duration: ${duration}ms`, `unsaved: ${!!doc.hasClientChanged}`);
         doc.destroy();
         docs.delete(doc.name);
       }
@@ -485,8 +485,6 @@ export const persistence = {
 
     ydoc.on('update', async () => {
       // Whenever we receive an update on the document store it in the local storage
-      // eslint-disable-next-line no-param-reassign
-      ydoc.isDirty = true;
       if (ydoc === docs.get(docName)) { // make sure this ydoc is still active
         try {
           await storeState(docName, Y.encodeStateAsUpdate(ydoc), storage);
@@ -511,7 +509,7 @@ export const persistence = {
       try {
         current = await persistence.update(ydoc, current, docName);
         // eslint-disable-next-line no-param-reassign
-        ydoc.isDirty = false;
+        ydoc.hasClientChanged = false;
       } finally {
         saving = false;
       }

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -1891,4 +1891,193 @@ describe('Collab Test Suite', () => {
     assert.equal(false, isExpectedPlatformEvent(null));
     assert.equal(false, isExpectedPlatformEvent(undefined));
   });
+
+  it('setupWSConnection sets connectedAt on conn', async () => {
+    const savedBind = persistence.bindState;
+    try {
+      persistence.bindState = async () => new Map();
+
+      const docName = 'https://somewhere.com/connectedat.html';
+      const mockConn = {
+        addEventListener() {},
+        close() {},
+        readyState: 1,
+        send() {},
+      };
+
+      const before = Date.now();
+      await setupWSConnection(mockConn, docName, {}, {});
+      const after = Date.now();
+
+      assert(typeof mockConn.connectedAt === 'number', 'connectedAt should be a number');
+      assert(mockConn.connectedAt >= before, 'connectedAt should be >= before timestamp');
+      assert(mockConn.connectedAt <= after, 'connectedAt should be <= after timestamp');
+    } finally {
+      persistence.bindState = savedBind;
+    }
+  });
+
+  it('closeConn logs duration and unsaved: false when isDirty is false', () => {
+    const logged = [];
+    const savedLog = console.log;
+    console.log = (...args) => logged.push(args);
+
+    try {
+      const docName = 'http://foo.bar/logtest.html';
+      const mockDoc = {
+        isDirty: false,
+        name: docName,
+        conns: new Map(),
+        awareness: { states: new Map() },
+        destroy() {},
+      };
+
+      const mockConn = {
+        connectedAt: Date.now() - 1500,
+        close() {},
+      };
+      mockDoc.conns.set(mockConn, new Set());
+      setYDoc(docName, mockDoc);
+
+      closeConn(mockDoc, mockConn);
+
+      const lastCloseLog = logged.find((args) => args[0] === '[docroom] Last connection closed');
+      assert(lastCloseLog, 'Should have logged last connection closed');
+      assert.equal(lastCloseLog[1], docName);
+      assert.match(lastCloseLog[2], /^duration: \d+ms$/);
+      assert.equal(lastCloseLog[3], 'unsaved: false');
+    } finally {
+      console.log = savedLog;
+    }
+  });
+
+  it('closeConn logs unsaved: true when isDirty is true', () => {
+    const logged = [];
+    const savedLog = console.log;
+    console.log = (...args) => logged.push(args);
+
+    try {
+      const docName = 'http://foo.bar/logtest-dirty.html';
+      const mockDoc = {
+        isDirty: true,
+        name: docName,
+        conns: new Map(),
+        awareness: { states: new Map() },
+        destroy() {},
+      };
+
+      const mockConn = {
+        connectedAt: Date.now() - 500,
+        close() {},
+      };
+      mockDoc.conns.set(mockConn, new Set());
+      setYDoc(docName, mockDoc);
+
+      closeConn(mockDoc, mockConn);
+
+      const lastCloseLog = logged.find((args) => args[0] === '[docroom] Last connection closed');
+      assert(lastCloseLog, 'Should have logged last connection closed');
+      assert.equal(lastCloseLog[1], docName);
+      assert.equal(lastCloseLog[3], 'unsaved: true');
+    } finally {
+      console.log = savedLog;
+    }
+  });
+
+  it('persistence.update logs save success when content changed', async () => {
+    const mockDoc2Aem = () => 'new content';
+    const pss = await esmock('../src/shareddoc.js', {
+      '@da-tools/da-parser': {
+        doc2aem: mockDoc2Aem,
+      },
+    });
+
+    const mockYDoc = {
+      conns: { keys() { return [{}]; } },
+      name: 'http://foo.bar/0/save-log.html',
+    };
+
+    pss.persistence.put = async () => ({ ok: true, status: 200, statusText: 'OK' });
+
+    const logged = [];
+    const savedLog = console.log;
+    console.log = (...args) => logged.push(args);
+
+    try {
+      const result = await pss.persistence.update(mockYDoc, 'old content', 'save-log.html');
+      assert.equal(result, 'new content');
+
+      const saveLog = logged.find((args) => args[0] === '[docroom] Saved to da-admin');
+      assert(saveLog, 'Should have logged save success');
+      assert.equal(saveLog[1], 'save-log.html');
+      assert.equal(saveLog[2], `${'new content'.length}b`);
+    } finally {
+      console.log = savedLog;
+    }
+  });
+
+  it('debounced save logs skip when saving is true', async () => {
+    const mockdebounce = (f) => {
+      const debounced = async () => f();
+      debounced.cancel = () => {};
+      return debounced;
+    };
+    const pss = await esmock('../src/shareddoc.js', {
+      'lodash/debounce.js': {
+        default: mockdebounce,
+      },
+    });
+
+    const docName = 'https://admin.da.live/source/skip-save.html';
+    const storage = { list: async () => new Map() };
+    const updObservers = [];
+    const ydoc = new pss.WSSharedDoc(docName);
+    const originalOn = ydoc.on.bind(ydoc);
+    ydoc.on = (ev, handler) => {
+      if (ev === 'update') updObservers.push(handler);
+      return originalOn(ev, handler);
+    };
+    pss.setYDoc(docName, ydoc);
+
+    const savedSetTimeout = globalThis.setTimeout;
+    try {
+      globalThis.setTimeout = (f) => {
+        globalThis.setTimeout = savedSetTimeout;
+        f();
+      };
+
+      pss.persistence.get = async () => '<main><div>initial</div></main>';
+
+      let putCallCount = 0;
+      pss.persistence.put = async () => {
+        putCallCount += 1;
+        await new Promise((resolve) => {
+          savedSetTimeout(resolve, 50);
+        });
+        return { ok: true, status: 200, statusText: 'OK' };
+      };
+
+      await pss.persistence.bindState(docName, ydoc, {}, storage);
+      assert.equal(updObservers.length, 2, 'Precondition: two update observers registered');
+
+      const logged = [];
+      const savedLog = console.log;
+      console.log = (...args) => logged.push(args);
+
+      try {
+        const p1 = updObservers[1]();
+        const p2 = updObservers[1]();
+        await Promise.all([p1, p2]);
+
+        const skipLog = logged.find((args) => args[0] === '[docroom] Skip save: concurrent save in progress');
+        assert(skipLog, 'Should have logged concurrent save skip');
+        assert.equal(skipLog[1], docName);
+        assert.equal(putCallCount, 1, 'Only one PUT should have been made');
+      } finally {
+        console.log = savedLog;
+      }
+    } finally {
+      globalThis.setTimeout = savedSetTimeout;
+    }
+  });
 });

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -1917,7 +1917,7 @@ describe('Collab Test Suite', () => {
     }
   });
 
-  it('closeConn logs duration and unsaved: false when isDirty is false', () => {
+  it('closeConn logs duration and unsaved: false when hasClientChanged is false', () => {
     const logged = [];
     const savedLog = console.log;
     console.log = (...args) => logged.push(args);
@@ -1925,7 +1925,7 @@ describe('Collab Test Suite', () => {
     try {
       const docName = 'http://foo.bar/logtest.html';
       const mockDoc = {
-        isDirty: false,
+        hasClientChanged: false,
         name: docName,
         conns: new Map(),
         awareness: { states: new Map() },
@@ -1951,7 +1951,7 @@ describe('Collab Test Suite', () => {
     }
   });
 
-  it('closeConn logs unsaved: true when isDirty is true', () => {
+  it('closeConn logs unsaved: true when hasClientChanged is true', () => {
     const logged = [];
     const savedLog = console.log;
     console.log = (...args) => logged.push(args);
@@ -1959,7 +1959,7 @@ describe('Collab Test Suite', () => {
     try {
       const docName = 'http://foo.bar/logtest-dirty.html';
       const mockDoc = {
-        isDirty: true,
+        hasClientChanged: true,
         name: docName,
         conns: new Map(),
         awareness: { states: new Map() },
@@ -1995,6 +1995,7 @@ describe('Collab Test Suite', () => {
     const mockYDoc = {
       conns: { keys() { return [{}]; } },
       name: 'http://foo.bar/0/save-log.html',
+      hasClientChanged: true,
     };
 
     pss.persistence.put = async () => ({ ok: true, status: 200, statusText: 'OK' });


### PR DESCRIPTION
## Summary

- Logs session duration and unsaved state when the last WebSocket connection closes: `[docroom] Last connection closed <url> duration: <N>ms unsaved: true|false`
- Logs when a save to da-admin succeeds: `[docroom] Saved to da-admin <url> <N>b`
- Logs when a concurrent save is already in progress (the `saving` guard fires): `[docroom] Skip save: concurrent save in progress <url>`
- Resets `hasClientChanged` to `false` after each successful save, so the `unsaved` flag at close time reflects the state since the last save — not the entire session lifetime
- Reuses `hasClientChanged` (introduced in #142) rather than adding a new flag

These logs directly address the gap identified in [issue #145](https://github.com/adobe/da-collab/issues/145): session durations were not visible in Coralogix worker traces, making it impossible to correlate session cancellations with missed saves.

## Test plan

- [x] `npm test` — 103 tests pass, 100% coverage
- [x] `npm run lint` — 0 errors
- [x] New tests: `conn.connectedAt` set on connection, `closeConn` logs duration + `unsaved: false/true`, `persistence.update` logs save success, debounced save logs concurrent-skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)