### PR TITLE
feat: flush pending save on last WebSocket connection close

### DIFF
--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -66,7 +66,7 @@ function getDocType(docName) {
  * @param {ydoc} doc - the ydoc to close the connection for.
  * @param {WebSocket} conn - the websocket connection to close.
  */
-export const closeConn = (doc, conn) => {
+export const closeConn = async (doc, conn) => {
   try {
     if (doc.conns.has(conn)) {
       const controlledIds = doc.conns.get(conn);
@@ -81,6 +81,11 @@ export const closeConn = (doc, conn) => {
       }
 
       if (doc.conns.size === 0) {
+        if (doc.flushSave) {
+          // eslint-disable-next-line no-console
+          console.log('[docroom] Flushing pending save on last connection close', doc.name);
+          await doc.flushSave();
+        }
         const duration = conn.connectedAt ? Date.now() - conn.connectedAt : 0;
         // eslint-disable-next-line no-console
         console.log('[docroom] Last connection closed', doc.name, `duration: ${duration}ms`, `unsaved: ${!!doc.hasClientChanged}`);
@@ -371,8 +376,10 @@ export const persistence = {
     }
     if (closeAll) {
       // We had an unauthorized from da-admin - lets reset the connections
-      Array.from(ydoc.conns.keys())
-        .forEach((con) => persistence.closeConn(ydoc, con));
+      for (const con of Array.from(ydoc.conns.keys())) {
+        // eslint-disable-next-line no-await-in-loop
+        await persistence.closeConn(ydoc, con);
+      }
     }
     return current;
   },
@@ -496,9 +503,7 @@ export const persistence = {
     });
 
     let saving = false;
-    ydoc.on('update', debounce(async () => {
-      // If we receive an update on the document, store it in da-admin, but debounce it
-      // to avoid excessive da-admin calls.
+    const saveToAdmin = async () => {
       if (saving) {
         // eslint-disable-next-line no-console
         console.log('[docroom] Skip save: concurrent save in progress', docName);
@@ -513,7 +518,15 @@ export const persistence = {
       } finally {
         saving = false;
       }
-    }, 2000, { maxWait: 10000 }));
+    };
+
+    const debouncedSave = debounce(saveToAdmin, 2000, { maxWait: 10000 });
+    ydoc.on('update', debouncedSave);
+
+    ydoc.flushSave = async () => {
+      debouncedSave.cancel();
+      await saveToAdmin();
+    };
 
     const timingMap = new Map();
     timingMap.set('timingReadStateDuration', timingReadStateDuration);

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -677,6 +677,12 @@ describe('Collab Test Suite', () => {
     // Trigger 412 which closes all connections and removes from global map
     await pss.persistence.update(ydoc, '<main><div><p>initial</p></div></main>', 'test.html');
 
+    // Flush pending microtasks: the flushSave path inside closeConn (triggered by the
+    // aem2doc update event above) is async and may still be completing.
+    await new Promise((r) => {
+      setTimeout(r, 0);
+    });
+
     assert(!docs.has(docName), 'Doc should be removed from global map');
 
     // Now try to call the update handlers -
@@ -788,7 +794,7 @@ describe('Collab Test Suite', () => {
 
     assert.equal(0, called.length, 'Precondition');
     assert(docs.get(mockDoc.name), 'Precondition');
-    closeConn(mockDoc, mockConn);
+    await closeConn(mockDoc, mockConn);
     assert.deepStrictEqual(['close'], called);
     assert.equal(0, mockDoc.conns.size);
     assert.deepStrictEqual(
@@ -820,6 +826,180 @@ describe('Collab Test Suite', () => {
     assert.equal(0, called.length, 'Precondition');
     closeConn(mockDoc, mockConn);
     assert.deepStrictEqual(['close'], called);
+  });
+
+  it('Flush fires on last connection close', async () => {
+    const flushCalled = [];
+    const destroyCalled = [];
+    const mockDoc = {
+      name: 'http://flush.test/doc.html',
+      destroyed: false,
+      awareness: {
+        emit() {},
+        states: new Map(),
+      },
+      conns: new Map(),
+      destroy() {
+        destroyCalled.push('destroy');
+        this.destroyed = true;
+      },
+      flushSave: async () => {
+        flushCalled.push('flush');
+      },
+    };
+
+    const docs = setYDoc(mockDoc.name, mockDoc);
+    const mockConn = { close() {} };
+    mockDoc.conns.set(mockConn, new Set());
+
+    assert.equal(0, flushCalled.length, 'Precondition: flush not yet called');
+    assert(docs.has(mockDoc.name), 'Precondition: doc in global map');
+
+    await closeConn(mockDoc, mockConn);
+
+    assert.deepStrictEqual(['flush'], flushCalled, 'flushSave must be called');
+    assert.deepStrictEqual(['destroy'], destroyCalled, 'destroy must be called after flush');
+    assert(!docs.has(mockDoc.name), 'Doc must be removed from global map');
+  });
+
+  it('Flush is a no-op when nothing is pending', async () => {
+    const unchangedContent = '<main><div><p>unchanged</p></div></main>';
+    const mockdebounce = (f) => {
+      const debounced = async () => f();
+      debounced.cancel = () => {};
+      return debounced;
+    };
+    const pss = await esmock('../src/shareddoc.js', {
+      'lodash/debounce.js': { default: mockdebounce },
+      '@da-tools/da-parser': {
+        doc2aem: () => unchangedContent,
+        doc2json: () => '{}',
+        aem2doc,
+        json2doc: () => {},
+      },
+    });
+
+    const docName = 'https://admin.da.live/source/flush-noop.html';
+    const storage = { list: async () => new Map() };
+    const ydoc = new pss.WSSharedDoc(docName);
+    pss.setYDoc(docName, ydoc);
+
+    const putCalls = [];
+    pss.persistence.get = async () => unchangedContent;
+    pss.persistence.put = async () => {
+      putCalls.push('put');
+      return { ok: true, status: 200 };
+    };
+
+    const conn = { auth: undefined, close() {} };
+    await pss.persistence.bindState(docName, ydoc, conn, storage);
+
+    assert(typeof ydoc.flushSave === 'function', 'flushSave should be defined after bindState');
+
+    await ydoc.flushSave();
+
+    assert.equal(0, putCalls.length, 'PUT must not be called when nothing has changed');
+  });
+
+  it('Flush saves unsaved changes when debounce has not fired', async () => {
+    let cancelCalled = false;
+    const mockdebounce = (f) => {
+      const debounced = async () => f();
+      debounced.cancel = () => {
+        cancelCalled = true;
+      };
+      return debounced;
+    };
+    const pss = await esmock('../src/shareddoc.js', {
+      'lodash/debounce.js': { default: mockdebounce },
+      '@da-tools/da-parser': {
+        doc2aem: () => '<main><div><p>updated content</p></div></main>',
+        doc2json: () => '{}',
+        aem2doc,
+        json2doc: () => {},
+      },
+    });
+
+    const docName = 'https://admin.da.live/source/flush-saves.html';
+    const storage = { list: async () => new Map() };
+    const ydoc = new pss.WSSharedDoc(docName);
+    pss.setYDoc(docName, ydoc);
+
+    const putCalls = [];
+    pss.persistence.get = async () => '<main><div><p>initial content</p></div></main>';
+    pss.persistence.put = async (doc, content) => {
+      putCalls.push(content);
+      return { ok: true, status: 200 };
+    };
+
+    const conn = { auth: undefined, close() {} };
+    await pss.persistence.bindState(docName, ydoc, conn, storage);
+
+    assert(typeof ydoc.flushSave === 'function', 'flushSave must be set after bindState');
+
+    await ydoc.flushSave();
+
+    assert.equal(1, putCalls.length, 'PUT must be called once with pending changes');
+    assert(putCalls[0].includes('updated content'), 'PUT body must contain the changed content');
+  });
+
+  it('Flush cancels the pending debounce', async () => {
+    let cancelCalled = false;
+    const mockdebounce = (f) => {
+      const debounced = async () => f();
+      debounced.cancel = () => {
+        cancelCalled = true;
+      };
+      return debounced;
+    };
+    const pss = await esmock('../src/shareddoc.js', {
+      'lodash/debounce.js': { default: mockdebounce },
+    });
+
+    const docName = 'https://admin.da.live/source/flush-cancel.html';
+    const storage = { list: async () => new Map() };
+    const ydoc = new pss.WSSharedDoc(docName);
+    pss.setYDoc(docName, ydoc);
+
+    pss.persistence.get = async () => '<main><div><p>content</p></div></main>';
+    pss.persistence.put = async () => ({ ok: true, status: 200 });
+
+    const conn = { auth: undefined, close() {} };
+    await pss.persistence.bindState(docName, ydoc, conn, storage);
+
+    assert(!cancelCalled, 'Precondition: cancel not yet called');
+
+    await ydoc.flushSave();
+
+    assert(cancelCalled, 'debouncedSave.cancel() must be called during flush');
+  });
+
+  it('Non-last connection close does not flush', async () => {
+    const flushCalled = [];
+    const mockDoc = {
+      name: 'http://flush.test/multi-conn.html',
+      awareness: {
+        emit() {},
+        states: new Map(),
+      },
+      conns: new Map(),
+      destroy() {},
+      flushSave: async () => { flushCalled.push('flush'); },
+    };
+
+    const docs = setYDoc(mockDoc.name, mockDoc);
+    const conn1 = { close() {} };
+    const conn2 = { close() {} };
+    mockDoc.conns.set(conn1, new Set());
+    mockDoc.conns.set(conn2, new Set());
+
+    assert.equal(2, mockDoc.conns.size, 'Precondition: two connections');
+
+    await closeConn(mockDoc, conn1);
+
+    assert.equal(0, flushCalled.length, 'flushSave must NOT be called when connections remain');
+    assert.equal(1, mockDoc.conns.size, 'One connection must remain');
+    assert(docs.has(mockDoc.name), 'Doc must still be in global map');
   });
 
   it('Test bindState read from da-admin for doc', async () => {

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -937,6 +937,7 @@ describe('Collab Test Suite', () => {
 
     assert(typeof ydoc.flushSave === 'function', 'flushSave must be set after bindState');
 
+    ydoc.hasClientChanged = true;
     await ydoc.flushSave();
 
     assert.equal(1, putCalls.length, 'PUT must be called once with pending changes');


### PR DESCRIPTION
Fix #145 - at least, based on current theoretical analysis 

## Summary

- Extracts the debounced save logic into a named `saveToAdmin` function shared between the debounce path and a new flush path
- Stores `ydoc.flushSave` — an async function that cancels the pending debounce and immediately awaits `saveToAdmin`
- Makes `closeConn` async; when the last connection closes it awaits `doc.flushSave()` before `doc.destroy()` / `docs.delete()`, preserving the `ydoc !== docs.get(docName)` guard during the flush
- Properly awaits `closeConn` in the `closeAll` (401/403/412) cleanup loop
- Logs `[docroom] Flushing pending save on last connection close` when a flush fires

This eliminates the race between the 2s debounced save and session cancellations caused by VPN proxies, Durable Object migrations, or worker upgrades — all three identified as loss vectors in the [#145 analysis](https://github.com/adobe/da-collab/issues/145#issuecomment-4438443422).

## Test plan

- [x] `npm test` — 99 tests pass, 100% coverage
- [x] `npm run lint` — 0 errors
- [x] New tests: flush fires on last-conn-close, flush is no-op when nothing pending, flush saves unsaved changes, flush cancels the debounce, non-last-conn-close does not flush

🤖 Generated with [Claude Code](https://claude.com/claude-code)