### PR TITLE
fix(edge): signal WebSocket auth failures with custom close codes

### DIFF
--- a/src/edge.js
+++ b/src/edge.js
@@ -130,6 +130,27 @@ async function handleApiCall(url, request, env) {
 }
 
 /**
+ * Build a 101 response whose server-side WebSocket has already been closed
+ * with a custom code. This lets the client distinguish auth failures
+ * (CloseEvent.code 4401/4403) from generic handshake failures, which the
+ * browser would otherwise surface only as opaque code 1006.
+ *
+ * @param {Headers} reqHeaders
+ * @param {number} code - close code in the application range (4000-4999)
+ * @param {string} reason
+ */
+export function wsAuthFailureResponse(reqHeaders, code, reason) {
+  // eslint-disable-next-line no-undef
+  const [client, server] = new WebSocketPair();
+  server.accept();
+  server.close(code, reason);
+  const respHeaders = new Headers();
+  const protocols = reqHeaders.get('sec-websocket-protocol')?.split(',');
+  if (protocols?.includes('yjs')) respHeaders.set('sec-websocket-protocol', 'yjs');
+  return new Response(null, { status: 101, headers: respHeaders, webSocket: client });
+}
+
+/**
  * This is where the requests for the worker come in. They can either be pure API requests or
  * requests to set up a session with a Durable Object through a Yjs WebSocket.
  *
@@ -192,6 +213,17 @@ export async function handleApiRequest(request, env) {
     if (!initialReq.ok) {
       // eslint-disable-next-line no-console
       console.log(`[worker] Unable to get resource ${docName}: ${initialReq.status} - ${initialReq.statusText}`);
+      // For WebSocket upgrades, signal auth failures via a CloseEvent code so the
+      // client can refresh its token and reconnect (4401) or stop trying (4403).
+      // Otherwise the browser sees only a generic 1006.
+      if (request.headers.get('Upgrade') === 'websocket') {
+        if (initialReq.status === 401) {
+          return wsAuthFailureResponse(request.headers, 4401, 'auth');
+        }
+        if (initialReq.status === 403) {
+          return wsAuthFailureResponse(request.headers, 4403, 'forbidden');
+        }
+      }
       return new Response('unable to get resource', { status: initialReq.status });
     }
 

--- a/src/edge.js
+++ b/src/edge.js
@@ -146,7 +146,9 @@ export function wsAuthFailureResponse(reqHeaders, code, reason) {
   server.close(code, reason);
   const respHeaders = new Headers();
   const protocols = reqHeaders.get('sec-websocket-protocol')?.split(',');
-  if (protocols?.includes('yjs')) respHeaders.set('sec-websocket-protocol', 'yjs');
+  if (protocols?.includes('yjs')) {
+    respHeaders.set('sec-websocket-protocol', 'yjs');
+  }
   return new Response(null, { status: 101, headers: respHeaders, webSocket: client });
 }
 

--- a/test/edge.test.js
+++ b/test/edge.test.js
@@ -824,7 +824,7 @@ describe('Worker test suite', () => {
     assert.equal('unable to get resource', await res.text());
   });
 
-  it('Test handleApiRequest not authorized', async () => {
+  it('Test handleApiRequest not authorized (non-WS)', async () => {
     const req = {
       url: 'http://do.re.mi/https://admin.da.live/hihi.html',
       headers: new Headers(),
@@ -836,6 +836,72 @@ describe('Worker test suite', () => {
 
     const res = await handleApiRequest(req, env);
     assert.equal(401, res.status);
+  });
+
+  it('Test handleApiRequest not authorized (WS upgrade) -> 4401 close', async () => {
+    const req = {
+      url: 'http://do.re.mi/https://admin.da.live/hihi.html',
+      headers: new Headers({ Upgrade: 'websocket', 'sec-websocket-protocol': 'yjs, stale-token' }),
+    };
+
+    const mockFetch = async (url, opts) => new Response(null, { status: 401 });
+    const env = { daadmin: { fetch: mockFetch } };
+
+    const closeCalls = [];
+    globalThis.WebSocketPair = function MockWSP() {
+      const server = {
+        accept() {},
+        close(c, r) {
+          closeCalls.push([c, r]);
+        },
+      };
+      const client = {};
+      return [client, server];
+    };
+    try {
+      try {
+        const res = await handleApiRequest(req, env);
+        assert.equal(101, res.status);
+        assert.equal('yjs', res.headers.get('sec-websocket-protocol'));
+      } catch (e) {
+        // status 101 may not be valid in node test env; close assertion below covers it
+      }
+      assert.deepEqual(closeCalls, [[4401, 'auth']]);
+    } finally {
+      delete globalThis.WebSocketPair;
+    }
+  });
+
+  it('Test handleApiRequest forbidden (WS upgrade) -> 4403 close', async () => {
+    const req = {
+      url: 'http://do.re.mi/https://admin.da.live/hihi.html',
+      headers: new Headers({ Upgrade: 'websocket', 'sec-websocket-protocol': 'yjs, t' }),
+    };
+
+    const mockFetch = async (url, opts) => new Response(null, { status: 403 });
+    const env = { daadmin: { fetch: mockFetch } };
+
+    const closeCalls = [];
+    globalThis.WebSocketPair = function MockWSP() {
+      const server = {
+        accept() {},
+        close(c, r) {
+          closeCalls.push([c, r]);
+        },
+      };
+      return [{}, server];
+    };
+    try {
+      try {
+        const res = await handleApiRequest(req, env);
+        assert.equal(101, res.status);
+      } catch (e) {
+        // status 101 may not be valid in node test env; close assertion below covers it
+      }
+      assert.deepEqual(closeCalls, [[4403, 'forbidden']]);
+    } finally {
+      delete globalThis.WebSocketPair;
+    }
   });
 
   it('Test handleApiRequest da-admin fetch exception', async () => {


### PR DESCRIPTION
When the da-admin HEAD rejects a WebSocket upgrade, return 101 + an immediately-closed WebSocket with code 4401 (auth) or 4403 (forbidden) instead of an HTTP error that the browser surfaces only as opaque 1006. This lets the client distinguish token-expired from network failures and refresh its IMS token before reconnecting.
