### PR TITLE
fix(shareddoc): preserve unsaved edits across persist-401 reconnect

### DIFF
--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -366,11 +366,33 @@ export const persistence = {
             }
           }
           closeAll = (status === 401 || status === 403 || status === 412);
+          if ((status === 401 || status === 403) && ydoc.storage) {
+            // Mark that worker storage holds edits that never reached da-admin.
+            // bindState on the next reconnect will see this and skip its
+            // setTimeout fallback that reloads from the (stale) da-admin
+            // snapshot — which would otherwise silently overwrite the
+            // user's typed-but-unsaved edits when the rooted closeAll
+            // cascade below tears the doc down.
+            try {
+              await ydoc.storage.put('unsavedSinceSave', true);
+            } catch (markErr) {
+              // eslint-disable-next-line no-console
+              console.error('[docroom] Failed to mark unsavedSinceSave', markErr);
+            }
+          }
           throw new Error(`${status} - ${statusText}`);
         }
 
         // eslint-disable-next-line no-console
         console.log('[docroom] Saved to da-admin', docName, `${content.length}b`);
+        if (ydoc.storage) {
+          // Clear the unsaved-since-save marker now that da-admin has the
+          // current content. Tolerated failure — the marker is a hint, not
+          // a correctness requirement for this save's success.
+          try {
+            await ydoc.storage.delete('unsavedSinceSave');
+          } catch { /* ignore */ }
+        }
         return content;
       }
     } catch (err) {
@@ -411,6 +433,15 @@ export const persistence = {
     current = await persistence.get(docName, conn.auth, ydoc.daadmin);
     const timingDaAdminGetDuration = Date.now() - timingBeforeDaAdminGet;
 
+    // If the previous incarnation of this room tore down on a persist 401/403,
+    // worker storage holds edits that never made it to da-admin. Read the
+    // marker before applying any state so the fallback below trusts storage
+    // instead of overwriting it with the stale da-admin snapshot.
+    let unsavedSinceSave = false;
+    try {
+      unsavedSinceSave = !!(await storage.get('unsavedSinceSave'));
+    } catch { /* non-fatal — marker is a hint */ }
+
     // Read the stored state from internal worker storage (errors are non-fatal)
     try {
       const timingBeforeReadState = Date.now();
@@ -429,6 +460,13 @@ export const persistence = {
 
           // eslint-disable-next-line no-console
           console.log('[docroom] Restored from worker persistence', docName);
+        } else if (unsavedSinceSave) {
+          // Worker storage diverges from da-admin because the last persist
+          // failed with 401/403, not because da-admin moved ahead. Treat
+          // storage as the source of truth and skip the da-admin fallback.
+          restored = true;
+          // eslint-disable-next-line no-console
+          console.log('[docroom] Trusting worker persistence (unsaved-since-save marker set)', docName);
         }
       }
     } catch (error) {

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -423,6 +423,72 @@ describe('Collab Test Suite', () => {
     await testCloseAllOnAuthFailure(403);
   });
 
+  async function testMarksUnsavedOnAuthFailure(httpError) {
+    const mockDoc2Aem = () => 'Svr content update';
+    const pss = await esmock('../src/shareddoc.js', {
+      '@da-tools/da-parser': { doc2aem: mockDoc2Aem },
+    });
+
+    const storageState = new Map();
+    const mockYDoc = {
+      conns: new Map().set('foo', 'bar'),
+      name: 'http://foo.bar/0/123.html',
+      hasClientChanged: true,
+      getMap(nm) { return nm === 'error' ? new Map() : null; },
+      transact: (f) => f(),
+      storage: {
+        async put(k, v) { storageState.set(k, v); },
+        async delete(k) { storageState.delete(k); },
+        async get(k) { return storageState.get(k); },
+      },
+    };
+
+    pss.persistence.put = async () => ({ ok: false, status: httpError, statusText: 'Unauthorized' });
+    pss.persistence.closeConn = () => {};
+
+    await pss.persistence.update(mockYDoc, 'Svr content', 'test.html');
+
+    assert.strictEqual(
+      storageState.get('unsavedSinceSave'),
+      true,
+      `unsavedSinceSave marker must be set after ${httpError}`,
+    );
+  }
+
+  it('Test persistence update marks unsavedSinceSave on 401/403', async () => {
+    await testMarksUnsavedOnAuthFailure(401);
+    await testMarksUnsavedOnAuthFailure(403);
+  });
+
+  it('Test persistence update clears unsavedSinceSave on successful put', async () => {
+    const mockDoc2Aem = () => 'Svr content update';
+    const pss = await esmock('../src/shareddoc.js', {
+      '@da-tools/da-parser': { doc2aem: mockDoc2Aem },
+    });
+
+    const storageState = new Map([['unsavedSinceSave', true]]);
+    const mockYDoc = {
+      conns: { keys() { return [{}]; } },
+      name: 'http://foo.bar/0/123.html',
+      hasClientChanged: true,
+      storage: {
+        async put(k, v) { storageState.set(k, v); },
+        async delete(k) { storageState.delete(k); },
+        async get(k) { return storageState.get(k); },
+      },
+    };
+
+    pss.persistence.put = async () => ({ ok: true, status: 201, statusText: 'Created' });
+
+    await pss.persistence.update(mockYDoc, 'Svr content', 'test.html');
+
+    assert.strictEqual(
+      storageState.has('unsavedSinceSave'),
+      false,
+      'unsavedSinceSave marker must be cleared after a successful save',
+    );
+  });
+
   it('Test persistence update skips PUT when content is empty stub and no client edit', async () => {
     // Reproduces COR-31 / COR-28: an unedited ydoc whose doc2aem output is the
     // deterministic empty stub must NOT overwrite real content in da-admin.
@@ -1113,6 +1179,58 @@ describe('Collab Test Suite', () => {
     await wait(1500);
 
     assert.equal(0, aem2DocCalled.length, 'da-admin reload should be skipped when the client sent state first');
+  });
+
+  it('Test bindState trusts worker storage and skips da-admin reload when unsavedSinceSave marker is set', async () => {
+    // Regression: when a prior persist failed with 401/403, persistence.update
+    // sets an unsavedSinceSave marker in DO storage and the closeAll cascade
+    // destroys the doc. The next bindState reads worker storage (which holds
+    // the unsaved edits) — without the marker check it would notice
+    // fromStorage !== current and schedule the setTimeout reload from da-admin
+    // that wipes the user's edits.
+    const aem2DocCalled = [];
+    const mockAem2Doc = (sc, yd) => aem2DocCalled.push(sc, yd);
+    const pss = await esmock('../src/shareddoc.js', {
+      '@da-tools/da-parser': { aem2doc: mockAem2Doc },
+    });
+
+    const docName = 'https://admin.da.live/source/org/repo/with-unsaved.html';
+
+    // Worker storage has yjs state with a client edit baked in
+    const seedYDoc = new Y.Doc();
+    seedYDoc.getMap('edits').set('typed', 'while-token-expired');
+    const storedState = Y.encodeStateAsUpdate(seedYDoc);
+    const storageMap = new Map();
+    storageMap.set('doc', docName);
+    storageMap.set('docstore', storedState);
+    storageMap.set('unsavedSinceSave', true);
+
+    const mockStorage = {
+      list: async () => storageMap,
+      get: async (k) => storageMap.get(k),
+    };
+
+    const testYDoc = new Y.Doc();
+    testYDoc.daadmin = 'daadmin';
+    const mockConn = { auth: 'myauth', authActions: ['read'] };
+    pss.setYDoc(docName, testYDoc);
+
+    // da-admin returns a STALE version that doesn't include the unsaved edit.
+    pss.persistence.get = async () => '<main><div><p>stale-from-da-admin</p></div></main>';
+    pss.persistence.update = async () => {};
+
+    await pss.persistence.bindState(docName, testYDoc, mockConn, mockStorage);
+
+    // Wait past the 1s setTimeout window — the reload must NOT fire because
+    // the marker tells us storage is ahead of da-admin.
+    await wait(1500);
+
+    assert.equal(
+      0,
+      aem2DocCalled.length,
+      'aem2doc must NOT be invoked when unsavedSinceSave is set — storage is the source of truth',
+    );
+    assert.equal('while-token-expired', testYDoc.getMap('edits').get('typed'));
   });
 
   it('Test bindState still reloads from da-admin when no client update arrives before timeout', async () => {


### PR DESCRIPTION
## Why

When `persistence.put` returns 401/403, the `closeAll` cascade tears the doc down: each conn is removed from `doc.conns`, the last `closeConn` runs `flushSave`, and `doc.destroy()` follows. The flush itself is silently broken — `persistence.put`'s auth extraction reads from `doc.conns.keys()` which has just been emptied by the same cascade, so the retry goes out without an `Authorization` header and fails again. The doc is gone; worker storage still has the edits.

The next reconnect's `bindState`:

1. Reads `current` from da-admin → the **stale** pre-edit snapshot.
2. Reads `stored` from worker storage → has the unsaved edits, applies them.
3. `fromStorage !== current` → `restored = false`.
4. Schedules a 1s `setTimeout` that **wipes the in-memory state and reloads from da-admin** unless the client pushes a Y.js update first.

If the client's reconnect dance takes longer than 1s (slow IMS refresh, multiple WS retries, slow network), the timer wins the race and the user's edits are gone.

## What

Track an `unsavedSinceSave` marker in DO storage so the next `bindState` can tell apart "storage lags da-admin" from "storage is ahead of da-admin because the last save failed":

- **`persistence.update`** writes `unsavedSinceSave: true` **before** throwing on 401/403. The marker is durable across the imminent doc destruction.
- **`persistence.update`** deletes the marker on a successful put.
- **`persistence.bindState`** reads the marker and treats worker storage as the source of truth (`restored = true`) when it is set, even if `fromStorage !== current`. The destructive da-admin fallback is skipped.

The marker is a hint — set/clear failures are swallowed and don't fail the save. The 412 path still calls `storage.deleteAll()` which sweeps the marker along with the rest of storage, so the doc-deleted recovery is unchanged.

## Tests

- `Test persistence update marks unsavedSinceSave on 401/403` — verifies the marker is set after either auth-failure code.
- `Test persistence update clears unsavedSinceSave on successful put` — verifies the marker is cleared after a 201, starting from a state where the marker is set.
- `Test bindState trusts worker storage and skips da-admin reload when unsavedSinceSave marker is set` — sets up storage with both yjs state and the marker, asserts `aem2doc` is not invoked after the 1s timeout window.
- All existing bindState/update tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)