### PR TITLE
fix(edge): suppress CF "Network connection lost." exceptions on WS auth failures

### DIFF
--- a/src/edge.js
+++ b/src/edge.js
@@ -143,6 +143,8 @@ export function wsAuthFailureResponse(reqHeaders, code, reason) {
   // eslint-disable-next-line no-undef
   const [client, server] = new WebSocketPair();
   server.accept();
+  server.addEventListener('error', () => {});
+  server.addEventListener('close', () => {});
   server.close(code, reason);
   const respHeaders = new Headers();
   const protocols = reqHeaders.get('sec-websocket-protocol')?.split(',');

--- a/test/edge.test.js
+++ b/test/edge.test.js
@@ -848,12 +848,12 @@ describe('Worker test suite', () => {
     const env = { daadmin: { fetch: mockFetch } };
 
     const closeCalls = [];
+    const addedListeners = [];
     globalThis.WebSocketPair = function MockWSP() {
       const server = {
         accept() {},
-        close(c, r) {
-          closeCalls.push([c, r]);
-        },
+        addEventListener(type) { addedListeners.push(type); },
+        close(c, r) { closeCalls.push([c, r]); },
       };
       const client = {};
       return [client, server];
@@ -867,6 +867,8 @@ describe('Worker test suite', () => {
         // status 101 may not be valid in node test env; close assertion below covers it
       }
       assert.deepEqual(closeCalls, [[4401, 'auth']]);
+      assert.ok(addedListeners.includes('error'), 'error listener must be registered to suppress CF "Network connection lost." exceptions');
+      assert.ok(addedListeners.includes('close'), 'close listener must be registered');
     } finally {
       delete globalThis.WebSocketPair;
     }
@@ -882,12 +884,12 @@ describe('Worker test suite', () => {
     const env = { daadmin: { fetch: mockFetch } };
 
     const closeCalls = [];
+    const addedListeners = [];
     globalThis.WebSocketPair = function MockWSP() {
       const server = {
         accept() {},
-        close(c, r) {
-          closeCalls.push([c, r]);
-        },
+        addEventListener(type) { addedListeners.push(type); },
+        close(c, r) { closeCalls.push([c, r]); },
       };
       return [{}, server];
     };
@@ -899,6 +901,8 @@ describe('Worker test suite', () => {
         // status 101 may not be valid in node test env; close assertion below covers it
       }
       assert.deepEqual(closeCalls, [[4403, 'forbidden']]);
+      assert.ok(addedListeners.includes('error'), 'error listener must be registered to suppress CF "Network connection lost." exceptions');
+      assert.ok(addedListeners.includes('close'), 'close listener must be registered');
     } finally {
       delete globalThis.WebSocketPair;
     }


### PR DESCRIPTION
## Summary

- `wsAuthFailureResponse` calls `server.accept()` which tells the Cloudflare runtime to start pumping WebSocket events to the Worker
- When the browser receives the 4401/4403 close frame it sends a close ack back — without `error`/`close` listeners registered on `server`, CF escalates that ack to an unhandled `Error: Network connection lost.` exception (`Outcome: exception`)
- This was generating **~2.8M spurious exceptions per 7 days** in production logs since #149

## Fix

Register no-op `error` and `close` listeners on `server` before calling `server.close()`, giving the CF runtime somewhere to deliver those events without escalating to an unhandled exception.

## Test plan

- [ ] Existing 4401/4403 close-code tests updated to assert that `error` and `close` listeners are registered on the server WebSocket
- [ ] `npm test` — 111 passing, 100% statement coverage
- [ ] `npm run lint` — clean
- [ ] After deploy: verify `Outcome: exception` + `Network connection lost.` count drops to near zero in Coralogix

🤖 Generated with [Claude Code](https://claude.com/claude-code)