### PR TITLE
revert: remove wsAuthFailureResponse (#149)

### DIFF
--- a/src/edge.js
+++ b/src/edge.js
@@ -131,32 +131,6 @@ async function handleApiCall(url, request, env) {
 }
 
 /**
- * Build a 101 response whose server-side WebSocket has already been closed
- * with a custom code. This lets the client distinguish auth failures
- * (CloseEvent.code 4401/4403) from generic handshake failures, which the
- * browser would otherwise surface only as opaque code 1006.
- *
- * @param {Headers} reqHeaders
- * @param {number} code - close code in the application range (4000-4999)
- * @param {string} reason
- */
-export function wsAuthFailureResponse(reqHeaders, code, reason) {
-  // eslint-disable-next-line no-undef
-  const [client, server] = new WebSocketPair();
-  server.accept();
-  // CF Workers requires at least one send() before close(); without it, close() throws
-  // a runtime-level "Network connection lost." exception that bypasses event listeners.
-  server.send(reason);
-  server.close(code, reason);
-  const respHeaders = new Headers();
-  const protocols = reqHeaders.get('sec-websocket-protocol')?.split(',');
-  if (protocols?.includes('yjs')) {
-    respHeaders.set('sec-websocket-protocol', 'yjs');
-  }
-  return new Response(null, { status: 101, headers: respHeaders, webSocket: client });
-}
-
-/**
  * This is where the requests for the worker come in. They can either be pure API requests or
  * requests to set up a session with a Durable Object through a Yjs WebSocket.
  *
@@ -219,17 +193,6 @@ export async function handleApiRequest(request, env) {
     if (!initialReq.ok) {
       // eslint-disable-next-line no-console
       console.log(`[worker] Unable to get resource ${docName}: ${initialReq.status} - ${initialReq.statusText}`);
-      // For WebSocket upgrades, signal auth failures via a CloseEvent code so the
-      // client can refresh its token and reconnect (4401) or stop trying (4403).
-      // Otherwise the browser sees only a generic 1006.
-      if (request.headers.get('Upgrade') === 'websocket') {
-        if (initialReq.status === 401) {
-          return wsAuthFailureResponse(request.headers, 4401, 'auth');
-        }
-        if (initialReq.status === 403) {
-          return wsAuthFailureResponse(request.headers, 4403, 'forbidden');
-        }
-      }
       return new Response('unable to get resource', { status: initialReq.status });
     }
 

--- a/test/edge.test.js
+++ b/test/edge.test.js
@@ -839,7 +839,7 @@ describe('Worker test suite', () => {
     assert.equal(401, res.status);
   });
 
-  it('Test handleApiRequest not authorized (WS upgrade) -> 4401 close', async () => {
+  it('Test handleApiRequest not authorized (WS upgrade) -> 401', async () => {
     const req = {
       url: 'http://do.re.mi/https://admin.da.live/hihi.html',
       headers: new Headers({ Upgrade: 'websocket', 'sec-websocket-protocol': 'yjs, stale-token' }),
@@ -848,32 +848,11 @@ describe('Worker test suite', () => {
     const mockFetch = async (url, opts) => new Response(null, { status: 401 });
     const env = { daadmin: { fetch: mockFetch } };
 
-    const ops = [];
-    globalThis.WebSocketPair = function MockWSP() {
-      const server = {
-        accept() { ops.push('accept'); },
-        send(msg) { ops.push(['send', msg]); },
-        close(c, r) { ops.push(['close', c, r]); },
-      };
-      const client = {};
-      return [client, server];
-    };
-    try {
-      try {
-        const res = await handleApiRequest(req, env);
-        assert.equal(101, res.status);
-        assert.equal('yjs', res.headers.get('sec-websocket-protocol'));
-      } catch (e) {
-        // status 101 may not be valid in node test env; close assertion below covers it
-      }
-      // send() must precede close() — CF requires it to avoid "Network connection lost." exception
-      assert.deepEqual(ops, ['accept', ['send', 'auth'], ['close', 4401, 'auth']]);
-    } finally {
-      delete globalThis.WebSocketPair;
-    }
+    const res = await handleApiRequest(req, env);
+    assert.equal(401, res.status);
   });
 
-  it('Test handleApiRequest forbidden (WS upgrade) -> 4403 close', async () => {
+  it('Test handleApiRequest forbidden (WS upgrade) -> 403', async () => {
     const req = {
       url: 'http://do.re.mi/https://admin.da.live/hihi.html',
       headers: new Headers({ Upgrade: 'websocket', 'sec-websocket-protocol': 'yjs, t' }),
@@ -882,27 +861,8 @@ describe('Worker test suite', () => {
     const mockFetch = async (url, opts) => new Response(null, { status: 403 });
     const env = { daadmin: { fetch: mockFetch } };
 
-    const ops = [];
-    globalThis.WebSocketPair = function MockWSP() {
-      const server = {
-        accept() { ops.push('accept'); },
-        send(msg) { ops.push(['send', msg]); },
-        close(c, r) { ops.push(['close', c, r]); },
-      };
-      return [{}, server];
-    };
-    try {
-      try {
-        const res = await handleApiRequest(req, env);
-        assert.equal(101, res.status);
-      } catch (e) {
-        // status 101 may not be valid in node test env; close assertion below covers it
-      }
-      // send() must precede close() — CF requires it to avoid "Network connection lost." exception
-      assert.deepEqual(ops, ['accept', ['send', 'forbidden'], ['close', 4403, 'forbidden']]);
-    } finally {
-      delete globalThis.WebSocketPair;
-    }
+    const res = await handleApiRequest(req, env);
+    assert.equal(403, res.status);
   });
 
   it('Test handleApiRequest da-admin fetch exception', async () => {


### PR DESCRIPTION
## Summary

Reverts the WebSocket auth failure signalling introduced in #149.

The `wsAuthFailureResponse` pattern (`accept()` + `close()` + return 101) causes the CF Workers runtime to throw an unhandled `Error: Network connection lost.` exception for **every** 401/403 on a WebSocket upgrade — ~15k exceptions per 30 minutes in production. Three fix attempts shipped as v1.5.1 and v1.5.2 (event listeners, `send()` before `close()`) all failed; the exception is thrown at the native CF runtime level before any JS handler can intercept it.

Restoring pre-#149 behaviour: WebSocket upgrade auth failures return plain HTTP 401/403. The browser client sees close code 1006, same as before #149.

## Test plan

- [ ] `npm test` — 123 passing, 100% statement coverage
- [ ] `npm run lint` — clean
- [ ] After deploy: verify `Outcome: exception` + `Network connection lost.` count drops to near zero in Coralogix

🤖 Generated with [Claude Code](https://claude.com/claude-code)