### PR TITLE
fix: wrap initSession in ctx.waitUntil to prevent early DO eviction

### DIFF
--- a/src/edge.js
+++ b/src/edge.js
@@ -425,7 +425,7 @@ export class DocRoom {
         auth ? auth.substring(0, auth.indexOf(' ')) : 'none'})`);
 
       // Kick off async document initialization; response is returned immediately.
-      this.initSession(server, docName);
+      this.ctx.waitUntil(this.initSession(server, docName));
 
       const reqHeaders = request.headers;
       const respheaders = new Headers({

--- a/test/edge.test.js
+++ b/test/edge.test.js
@@ -23,6 +23,7 @@ function makeCtx(storage = null) {
     storage,
     accepted,
     acceptWebSocket(ws) { accepted.push(ws); },
+    waitUntil(p) { return p; },
   };
 }
 


### PR DESCRIPTION
Without `ctx.waitUntil()`, the Cloudflare runtime may evict the Durable Object before `initSession` completes, silently dropping the async document initialization and leaving the WebSocket client connected but uninitialized.

## Change
Wrap the fire-and-forget `initSession` call in `ctx.waitUntil()` so the DO stays alive until session setup finishes. Also adds `waitUntil` stub to `makeCtx` in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)