### PR TITLE
perf: avoid loading full document on cold start in readState

### DIFF
--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -132,29 +132,38 @@ const send = (doc, conn, m) => {
  * @returns {Promise<Uint8Array | undefined>} - The stored state or undefined if not found
  */
 export const readState = async (docName, storage) => {
-  const stored = await storage.list();
-  if (stored.size === 0) {
+  const storedDoc = await storage.get('doc');
+  if (storedDoc === undefined) {
     // eslint-disable-next-line no-console
     console.log('[docroom] No stored doc in persistence');
     return undefined;
   }
 
-  if (stored.get('doc') !== docName) {
+  if (storedDoc !== docName) {
     // eslint-disable-next-line no-console
-    console.log('[docroom] Docname mismatch in persistence. Expected:', docName, 'found:', stored.get('doc'), 'Deleting storage');
+    console.log('[docroom] Docname mismatch in persistence. Expected:', docName, 'found:', storedDoc, 'Deleting storage');
     await storage.deleteAll();
     return undefined;
   }
 
-  if (stored.has('docstore')) {
+  const docstore = await storage.get('docstore');
+  if (docstore !== undefined) {
     // eslint-disable-next-line no-console
     console.log('[docroom] Document found in persistence');
-    return stored.get('docstore');
+    return docstore;
   }
 
+  const chunkCount = await storage.get('chunks');
+  if (chunkCount === undefined) {
+    return undefined;
+  }
+
+  const chunkKeys = Array.from({ length: chunkCount }, (_, i) => `chunk_${i}`);
+  const chunksMap = await storage.get(chunkKeys);
+
   const data = [];
-  for (let i = 0; i < stored.get('chunks'); i += 1) {
-    const chunk = stored.get(`chunk_${i}`);
+  for (let i = 0; i < chunkCount; i += 1) {
+    const chunk = chunksMap.get(`chunk_${i}`);
 
     // Note cannot use the spread operator here, as that goes via the stack and may lead to
     // stack overflow.

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -494,7 +494,7 @@ describe('Collab Test Suite', () => {
     });
 
     const docName = 'https://admin.da.live/source/reentrant.html';
-    const storage = { list: async () => new Map() };
+    const storage = { list: async () => new Map(), get: async () => undefined };
     const ydoc = new pss.WSSharedDoc(docName);
     pss.setYDoc(docName, ydoc);
 
@@ -757,6 +757,7 @@ describe('Collab Test Suite', () => {
     // Set up bindState which registers update handlers
     const storage = {
       list: async () => new Map(),
+      get: async () => undefined,
       deleteAll: async () => {},
       put: async () => {},
     };
@@ -975,7 +976,7 @@ describe('Collab Test Suite', () => {
     });
 
     const docName = 'https://admin.da.live/source/flush-noop.html';
-    const storage = { list: async () => new Map() };
+    const storage = { list: async () => new Map(), get: async () => undefined };
     const ydoc = new pss.WSSharedDoc(docName);
     pss.setYDoc(docName, ydoc);
 
@@ -1016,7 +1017,7 @@ describe('Collab Test Suite', () => {
     });
 
     const docName = 'https://admin.da.live/source/flush-saves.html';
-    const storage = { list: async () => new Map() };
+    const storage = { list: async () => new Map(), get: async () => undefined };
     const ydoc = new pss.WSSharedDoc(docName);
     pss.setYDoc(docName, ydoc);
 
@@ -1053,7 +1054,7 @@ describe('Collab Test Suite', () => {
     });
 
     const docName = 'https://admin.da.live/source/flush-cancel.html';
-    const storage = { list: async () => new Map() };
+    const storage = { list: async () => new Map(), get: async () => undefined };
     const ydoc = new pss.WSSharedDoc(docName);
     pss.setYDoc(docName, ydoc);
 
@@ -1090,7 +1091,7 @@ describe('Collab Test Suite', () => {
     });
 
     const docName = 'https://admin.da.live/source/flush-inflight.html';
-    const storage = { list: async () => new Map() };
+    const storage = { list: async () => new Map(), get: async () => undefined };
     const ydoc = new pss.WSSharedDoc(docName);
     pss.setYDoc(docName, ydoc);
 
@@ -1188,7 +1189,7 @@ describe('Collab Test Suite', () => {
     };
     pss.setYDoc(docName, testYDoc);
 
-    const mockStorage = { list: () => new Map() };
+    const mockStorage = { list: () => new Map(), get: async () => undefined };
 
     pss.persistence.get = async (nm, au, ad) => `Get: ${nm}-${au}-${ad}`;
     const updated = new Map();
@@ -1225,7 +1226,7 @@ describe('Collab Test Suite', () => {
     };
     pss.setYDoc(docName, testYDoc);
 
-    const mockStorage = { list: () => new Map() };
+    const mockStorage = { list: () => new Map(), get: async () => undefined };
 
     pss.persistence.get = async (nm, au, ad) => `Get: ${nm}-${au}-${ad}`;
     const updated = new Map();
@@ -1262,7 +1263,7 @@ describe('Collab Test Suite', () => {
     };
     pss.setYDoc(docName, testYDoc);
 
-    const mockStorage = { list: () => new Map() };
+    const mockStorage = { list: () => new Map(), get: async () => undefined };
     pss.persistence.get = async (nm, au, ad) => `Get: ${nm}-${au}-${ad}`;
     pss.persistence.update = async () => {};
 
@@ -1300,7 +1301,7 @@ describe('Collab Test Suite', () => {
     };
     pss.setYDoc(docName, testYDoc);
 
-    const mockStorage = { list: () => new Map() };
+    const mockStorage = { list: () => new Map(), get: async () => undefined };
     pss.persistence.get = async (nm, au, ad) => `Get: ${nm}-${au}-${ad}`;
     pss.persistence.update = async () => {};
 
@@ -1335,7 +1336,7 @@ describe('Collab Test Suite', () => {
     };
     pss.setYDoc(docName, testYDoc);
 
-    const mockStorage = { list: () => new Map() };
+    const mockStorage = { list: () => new Map(), get: async () => undefined };
     pss.persistence.get = async (nm, au, ad) => `Get: ${nm}-${au}-${ad}`;
     pss.persistence.update = async () => {};
 
@@ -1370,7 +1371,21 @@ describe('Collab Test Suite', () => {
     // Create a new YDoc which will be initialised from storage
     const ydoc = new Y.Doc();
     const conn = {};
-    const storage = { list: async () => stored };
+    const storage = {
+      list: async () => stored,
+      get: async (keyOrKeys) => {
+        if (Array.isArray(keyOrKeys)) {
+          const result = new Map();
+          keyOrKeys.forEach((k) => {
+            if (stored.has(k)) {
+              result.set(k, stored.get(k));
+            }
+          });
+          return result;
+        }
+        return stored.get(keyOrKeys);
+      },
+    };
 
     const savedGet = persistence.get;
     try {
@@ -1407,7 +1422,21 @@ describe('Collab Test Suite', () => {
 
     const ydoc = new Y.Doc();
     const conn = {};
-    const storage = { list: async () => stored };
+    const storage = {
+      list: async () => stored,
+      get: async (keyOrKeys) => {
+        if (Array.isArray(keyOrKeys)) {
+          const result = new Map();
+          keyOrKeys.forEach((k) => {
+            if (stored.has(k)) {
+              result.set(k, stored.get(k));
+            }
+          });
+          return result;
+        }
+        return stored.get(keyOrKeys);
+      },
+    };
 
     const savedGet = persistence.get;
     try {
@@ -1433,6 +1462,9 @@ describe('Collab Test Suite', () => {
 
     const storage = {
       list: async () => {
+        throw new Error('yikes');
+      },
+      get: async () => {
         throw new Error('yikes');
       },
     };
@@ -1470,7 +1502,7 @@ describe('Collab Test Suite', () => {
     });
 
     const docName = 'https://admin.da.live/source/foo/bar.html';
-    const storage = { list: async () => new Map() };
+    const storage = { list: async () => new Map(), get: async () => undefined };
     const updObservers = [];
     const ydoc = new Y.Doc();
     ydoc.on = (ev, fun) => {
@@ -1531,7 +1563,7 @@ describe('Collab Test Suite', () => {
     });
 
     const docName = 'https://admin.da.live/source/foo/bar.html';
-    const storage = { list: async () => new Map() };
+    const storage = { list: async () => new Map(), get: async () => undefined };
     const updObservers = [];
     const ydoc = new Y.Doc();
     ydoc.on = (ev, fun) => {
@@ -2084,30 +2116,61 @@ describe('Collab Test Suite', () => {
     assert.equal(1, decoding.readVarUint(decoder), 'ok must be 1 when no flushSave (nothing to flush)');
   });
 
+  function makeStorage(data = {}) {
+    const map = new Map(Object.entries(data));
+    return {
+      async list() { return map; },
+      async get(keyOrKeys) {
+        if (Array.isArray(keyOrKeys)) {
+          const result = new Map();
+          keyOrKeys.forEach((k) => {
+            if (map.has(k)) {
+              result.set(k, map.get(k));
+            }
+          });
+          return result;
+        }
+        return map.get(keyOrKeys);
+      },
+      async put(d) { Object.entries(d).forEach(([k, v]) => map.set(k, v)); },
+      async delete(keys) {
+        (Array.isArray(keys) ? keys : [keys]).forEach((k) => map.delete(k));
+      },
+      async deleteAll() { map.clear(); },
+    };
+  }
+
   it('readState not chunked', async () => {
     const docName = 'http://foo.bar/doc123.html';
-    const stored = new Map();
-    stored.set('docstore', new Uint8Array([254, 255]));
-    stored.set('chunks', 17); // should be ignored
-    stored.set('doc', docName);
-
-    const storage = { list: async () => stored };
+    const storage = makeStorage({
+      docstore: new Uint8Array([254, 255]),
+      chunks: 17, // should be ignored
+      doc: docName,
+    });
 
     const data = await readState(docName, storage);
     assert.deepStrictEqual(new Uint8Array([254, 255]), data);
   });
 
+  it('readState no stored doc returns undefined', async () => {
+    const storage = makeStorage({});
+
+    const data = await readState('http://foo.bar/doc123.html', storage);
+    assert.equal(data, undefined);
+  });
+
   it('readState doc mismatch', async () => {
     const docName = 'http://foo.bar/doc123.html';
-    const stored = new Map();
-    stored.set('docstore', new Uint8Array([254, 255]));
-    stored.set('chunks', 17); // should be ignored
-    stored.set('doc', 'http://foo.bar/doc456.html');
-
     const storageCalled = [];
-    const storage = {
-      list: async () => stored,
-      deleteAll: async () => storageCalled.push('deleteAll'),
+    const storage = makeStorage({
+      docstore: new Uint8Array([254, 255]),
+      chunks: 17, // should be ignored
+      doc: 'http://foo.bar/doc456.html',
+    });
+    const origDeleteAll = storage.deleteAll.bind(storage);
+    storage.deleteAll = async () => {
+      storageCalled.push('deleteAll');
+      return origDeleteAll();
     };
 
     const data = await readState(docName, storage);
@@ -2116,13 +2179,12 @@ describe('Collab Test Suite', () => {
   });
 
   it('readState chunked', async () => {
-    const stored = new Map();
-    stored.set('chunk_0', new Uint8Array([1, 2, 3]));
-    stored.set('chunk_1', new Uint8Array([4, 5]));
-    stored.set('chunks', 2);
-    stored.set('doc', 'mydoc');
-
-    const storage = { list: async () => stored };
+    const storage = makeStorage({
+      chunk_0: new Uint8Array([1, 2, 3]),
+      chunk_1: new Uint8Array([4, 5]),
+      chunks: 2,
+      doc: 'mydoc',
+    });
 
     const data = await readState('mydoc', storage);
     assert.deepStrictEqual(new Uint8Array([1, 2, 3, 4, 5]), data);
@@ -2369,7 +2431,21 @@ describe('Collab Test Suite', () => {
     const conn = {};
     const storage = {
       list: async () => stored,
-      get: async (key) => (key === 'lastsync' ? daAdminContent : undefined),
+      get: async (keyOrKeys) => {
+        if (Array.isArray(keyOrKeys)) {
+          const result = new Map();
+          keyOrKeys.forEach((k) => {
+            if (stored.has(k)) {
+              result.set(k, stored.get(k));
+            }
+          });
+          return result;
+        }
+        if (keyOrKeys === 'lastsync') {
+          return daAdminContent;
+        }
+        return stored.get(keyOrKeys);
+      },
     };
 
     const savedSetTimeout = globalThis.setTimeout;
@@ -2585,7 +2661,7 @@ describe('Collab Test Suite', () => {
     });
 
     const docName = 'https://admin.da.live/source/skip-save.html';
-    const storage = { list: async () => new Map() };
+    const storage = { list: async () => new Map(), get: async () => undefined };
     const updObservers = [];
     const ydoc = new pss.WSSharedDoc(docName);
     const originalOn = ydoc.on.bind(ydoc);


### PR DESCRIPTION
\`readState\` called \`storage.list()\` which loads ALL stored key-value pairs — including the full document content (potentially megabytes of chunks) — even in cases where the document is not found or the doc name doesn't match.

Replaced with targeted \`storage.get()\` calls: only fetch the \`doc\` key first, then \`docstore\` or chunks only if needed. For the chunked case, use \`storage.get(keys[])\` (batch get) to keep it to a single round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)