### PR TITLE
fix: await flushSave on WebSocket close to prevent data loss

### DIFF
--- a/src/edge.js
+++ b/src/edge.js
@@ -485,9 +485,9 @@ export class DocRoom {
    * @param {WebSocket} webSocket
    */
   // eslint-disable-next-line class-methods-use-this
-  webSocketClose(webSocket) {
+  async webSocketClose(webSocket) {
     const { docName } = webSocket.deserializeAttachment();
-    handleWebSocketClose(webSocket, docName);
+    await handleWebSocketClose(webSocket, docName);
   }
 
   /**
@@ -496,9 +496,9 @@ export class DocRoom {
    * @param {Error} error
    */
   // eslint-disable-next-line class-methods-use-this
-  webSocketError(webSocket, error) {
+  async webSocketError(webSocket, error) {
     logError(error, '[docroom] WebSocket error', error);
     const { docName } = webSocket.deserializeAttachment();
-    handleWebSocketClose(webSocket, docName);
+    await handleWebSocketClose(webSocket, docName);
   }
 }

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -912,9 +912,9 @@ export const handleWebSocketMessage = async (conn, docName, env, storage, messag
  * @param {WebSocket} conn - The WebSocket connection
  * @param {string} docName - The document name
  */
-export const handleWebSocketClose = (conn, docName) => {
+export const handleWebSocketClose = async (conn, docName) => {
   const doc = docs.get(docName);
   if (doc) {
-    closeConn(doc, conn);
+    await closeConn(doc, conn);
   }
 };

--- a/test/edge.test.js
+++ b/test/edge.test.js
@@ -1144,7 +1144,7 @@ describe('Worker test suite', () => {
     const m = setYDoc(docName, testYdoc);
 
     const dr = new DocRoom(makeCtx(null), {});
-    dr.webSocketClose(mockConn, 1000, 'Normal', true);
+    await dr.webSocketClose(mockConn, 1000, 'Normal', true);
 
     assert.deepStrictEqual(['close'], closeCalled);
     assert(!m.has(docName), 'Doc should be removed when no connections remain');
@@ -1167,7 +1167,7 @@ describe('Worker test suite', () => {
     const m = setYDoc(docName, testYdoc);
 
     const dr = new DocRoom(makeCtx(null), {});
-    dr.webSocketError(mockConn, new Error('connection reset'));
+    await dr.webSocketError(mockConn, new Error('connection reset'));
 
     assert.deepStrictEqual(['close'], closeCalled);
     assert(!m.has(docName), 'Doc should be removed on error');
@@ -1184,7 +1184,7 @@ describe('Worker test suite', () => {
     };
 
     const dr = new DocRoom(makeCtx(null), {});
-    dr.webSocketClose(mockConn, 1000, 'Normal', true);
+    await dr.webSocketClose(mockConn, 1000, 'Normal', true);
     // No assertion needed — test passes if close() is not called
   });
 


### PR DESCRIPTION
\`webSocketClose\` and \`webSocketError\` were synchronous but called \`handleWebSocketClose\` → \`closeConn\` which is async and does \`await doc.flushSave()\` on the last connection. Without the await, pending document saves are silently dropped when the last client disconnects.

## Changes
- \`handleWebSocketClose\` → async, awaits \`closeConn\`
- \`DocRoom.webSocketClose\` → async, awaits \`handleWebSocketClose\`
- \`DocRoom.webSocketError\` → async, awaits \`handleWebSocketClose\`
- Tests updated to await the now-async close/error handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)