### PR TITLE
fix: await messageListener so flush responses complete before ack

### DIFF
--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -903,7 +903,7 @@ export const handleWebSocketMessage = async (conn, docName, env, storage, messag
     doc = docs.get(docName);
   }
   if (doc) {
-    messageListener(conn, doc, new Uint8Array(message));
+    await messageListener(conn, doc, new Uint8Array(message));
   }
 };
 


### PR DESCRIPTION
\`messageListener\` is async and handles \`messageFlushRequest\` with \`await doc.flushSave()\` before sending a flush response to the client. Without \`await\` in \`handleWebSocketMessage\`, the caller returns before the save completes, causing the ack to be sent prematurely and errors to be silently swallowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)