### PR TITLE
refactor: extend DurableObject base class to unlock RPC

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy:ci": "node prepare-deploy.js && wrangler deploy -e ci  -c wrangler-versioned.toml",
     "deploy:prod": "node prepare-deploy.js && wrangler deploy -e production -c wrangler-versioned.toml",
     "deploy:stage": "node prepare-deploy.js && wrangler deploy -e stage -c wrangler-versioned.toml",
-    "test": "c8 mocha --inline-diffs --exit # --exit is needed because some test code triggers async listeners",
+    "test": "c8 mocha --import ./test/stubs/register.mjs --inline-diffs --exit # --exit is needed because some test code triggers async listeners",
     "test:it": "echo 'todo'",
     "test:postdeploy": "echo 'todo'",
     "prepare": "husky",

--- a/src/edge.js
+++ b/src/edge.js
@@ -9,6 +9,8 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+// eslint-disable-next-line import/no-unresolved
+import { DurableObject } from 'cloudflare:workers';
 import {
   handleWebSocketClose, handleWebSocketMessage,
   invalidateFromAdmin, logError, setupWSConnection,
@@ -318,20 +320,7 @@ export default {
  *
  * @tpye {Fetcher}
  */
-export class DocRoom {
-  constructor(controller, env) {
-    // `controller.storage` provides access to our durable storage. It provides a simple KV
-    // get()/put() interface.
-    this.storage = controller?.storage;
-
-    // `env` is our environment bindings (discussed earlier).
-    this.env = env;
-    this.id = controller?.id?.toString() || `no-controller-${new Date().getTime()}`;
-
-    // `ctx` is the Durable Object controller, used for the Hibernation API
-    this.ctx = controller;
-  }
-
+export class DocRoom extends DurableObject {
   /**
    * Handle the API calls. Supported API calls right now are to sync the doc with the da-admin
    * state or to indicate that the document has been deleted from da-admin.
@@ -454,7 +443,7 @@ export class DocRoom {
    */
   async initSession(webSocket, docName) {
     try {
-      await setupWSConnection(webSocket, docName, this.env, this.storage, true);
+      await setupWSConnection(webSocket, docName, this.env, this.ctx?.storage, true);
     } catch (err) {
       logError(err, '[docroom] Error during session setup', docName, err);
       try {
@@ -477,7 +466,7 @@ export class DocRoom {
       // eslint-disable-next-line no-param-reassign
       webSocket.readOnly = true;
     }
-    await handleWebSocketMessage(webSocket, docName, this.env, this.storage, message);
+    await handleWebSocketMessage(webSocket, docName, this.env, this.ctx?.storage, message);
   }
 
   /**

--- a/test/stubs/cloudflare-workers-hook.mjs
+++ b/test/stubs/cloudflare-workers-hook.mjs
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === 'cloudflare:workers') {
+    return {
+      shortCircuit: true,
+      url: new URL('./cloudflare-workers.js', import.meta.url).href,
+      format: 'module',
+    };
+  }
+  return nextResolve(specifier, context);
+}

--- a/test/stubs/cloudflare-workers.js
+++ b/test/stubs/cloudflare-workers.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// Stub for cloudflare:workers in the Node.js test environment
+export class DurableObject {
+  constructor(ctx, env) {
+    this.ctx = ctx;
+    this.env = env;
+  }
+}

--- a/test/stubs/register.mjs
+++ b/test/stubs/register.mjs
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { register } from 'node:module';
+
+register(
+  new URL('./cloudflare-workers-hook.mjs', import.meta.url).href,
+  import.meta.url,
+);


### PR DESCRIPTION
The modern Cloudflare Durable Objects pattern requires extending the \`DurableObject\` base class from \`cloudflare:workers\`. This is also a prerequisite for enabling RPC — direct method calls on DO stubs instead of round-tripping through \`fetch()\`. The current code acknowledges this limitation in a TODO comment.

## Changes
- \`DocRoom\` now extends \`DurableObject\` — \`this.ctx\` and \`this.env\` are set by the base class constructor
- Removes manual \`this.storage\`, \`this.env\`, \`this.ctx\`, and unused \`this.id\` assignments from the constructor
- Adds \`cloudflare:workers\` module stub and Node.js module hook so the existing Mocha test suite continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)