### PR TITLE
chore: bump compatibility_date to 2024-04-03 to enable RPC

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
 name = "da-collab"
 workers_dev = true
-compatibility_date = "2023-10-30"
+compatibility_date = "2024-04-03"
 main = "src/edge.js"
 keep_vars = true
 


### PR DESCRIPTION
The current \`compatibility_date = "2023-10-30"\` predates the Cloudflare Workers flag that enables RPC on Durable Objects. A comment in the codebase notes that admin APIs cannot call \`DocRoom.handleApiCall\` directly without enabling RPC.

\`2024-04-03\` is the minimum date that enables the RPC flag. Bumping to this date unblocks direct method calls on DO stubs as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)