### PR TITLE
docs: document SQLite migration path in wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,6 +9,10 @@ port = 4711
 
 [[migrations]]
 tag = "v1" # Should be unique for each entry
+# DocRoom uses the legacy KV-backed storage. Cloudflare now recommends
+# new_sqlite_classes for new Durable Object namespaces (SQLite-backed DOs
+# support SQL queries and 30-day point-in-time recovery). Migrating existing
+# instances requires a v2 migration tag, a new class, and a data migration.
 new_classes = ["DocRoom"]
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Cloudflare currently recommends \`new_sqlite_classes\` for Durable Object namespaces. \`DocRoom\` was created before this recommendation and uses the legacy KV-backed storage. A migration to SQLite requires a new migration tag and a proper data migration plan; this comment documents that intent for the next person who looks at this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)