### PR TITLE
fix: remove incorrect bind(this) from persistence.closeConn

### DIFF
--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -242,7 +242,7 @@ export const showError = (ydoc, err) => {
 };
 
 export const persistence = {
-  closeConn: closeConn.bind(this),
+  closeConn,
 
   /**
    * Get the document from da-admin.


### PR DESCRIPTION
At module scope in strict mode, \`this\` is \`undefined\`. The \`closeConn.bind(this)\` call in the \`persistence\` object has no effect since \`closeConn\` never references \`this\`. Using the function directly is clearer and removes the misleading \`bind\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)