### PR TITLE
fix: Durable Object best practices — all 9 fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy:ci": "node prepare-deploy.js && wrangler deploy -e ci  -c wrangler-versioned.toml",
     "deploy:prod": "node prepare-deploy.js && wrangler deploy -e production -c wrangler-versioned.toml",
     "deploy:stage": "node prepare-deploy.js && wrangler deploy -e stage -c wrangler-versioned.toml",
-    "test": "c8 mocha --inline-diffs --exit # --exit is needed because some test code triggers async listeners",
+    "test": "c8 mocha --import ./test/stubs/register.mjs --inline-diffs --exit # --exit is needed because some test code triggers async listeners",
     "test:it": "echo 'todo'",
     "test:postdeploy": "echo 'todo'",
     "prepare": "husky",

--- a/src/edge.js
+++ b/src/edge.js
@@ -9,6 +9,8 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+// eslint-disable-next-line import/no-unresolved
+import { DurableObject } from 'cloudflare:workers';
 import {
   handleWebSocketClose, handleWebSocketMessage,
   invalidateFromAdmin, logError, setupWSConnection,
@@ -318,20 +320,7 @@ export default {
  *
  * @tpye {Fetcher}
  */
-export class DocRoom {
-  constructor(controller, env) {
-    // `controller.storage` provides access to our durable storage. It provides a simple KV
-    // get()/put() interface.
-    this.storage = controller?.storage;
-
-    // `env` is our environment bindings (discussed earlier).
-    this.env = env;
-    this.id = controller?.id?.toString() || `no-controller-${new Date().getTime()}`;
-
-    // `ctx` is the Durable Object controller, used for the Hibernation API
-    this.ctx = controller;
-  }
-
+export class DocRoom extends DurableObject {
   /**
    * Handle the API calls. Supported API calls right now are to sync the doc with the da-admin
    * state or to indicate that the document has been deleted from da-admin.
@@ -454,7 +443,7 @@ export class DocRoom {
    */
   async initSession(webSocket, docName) {
     try {
-      await setupWSConnection(webSocket, docName, this.env, this.storage, true);
+      await setupWSConnection(webSocket, docName, this.env, this.ctx?.storage, true);
     } catch (err) {
       logError(err, '[docroom] Error during session setup', docName, err);
       try {
@@ -477,7 +466,7 @@ export class DocRoom {
       // eslint-disable-next-line no-param-reassign
       webSocket.readOnly = true;
     }
-    await handleWebSocketMessage(webSocket, docName, this.env, this.storage, message);
+    await handleWebSocketMessage(webSocket, docName, this.env, this.ctx?.storage, message);
   }
 
   /**

--- a/src/edge.js
+++ b/src/edge.js
@@ -485,9 +485,9 @@ export class DocRoom {
    * @param {WebSocket} webSocket
    */
   // eslint-disable-next-line class-methods-use-this
-  webSocketClose(webSocket) {
+  async webSocketClose(webSocket) {
     const { docName } = webSocket.deserializeAttachment();
-    handleWebSocketClose(webSocket, docName);
+    await handleWebSocketClose(webSocket, docName);
   }
 
   /**
@@ -496,9 +496,9 @@ export class DocRoom {
    * @param {Error} error
    */
   // eslint-disable-next-line class-methods-use-this
-  webSocketError(webSocket, error) {
+  async webSocketError(webSocket, error) {
     logError(error, '[docroom] WebSocket error', error);
     const { docName } = webSocket.deserializeAttachment();
-    handleWebSocketClose(webSocket, docName);
+    await handleWebSocketClose(webSocket, docName);
   }
 }

--- a/src/edge.js
+++ b/src/edge.js
@@ -454,7 +454,7 @@ export class DocRoom {
    */
   async initSession(webSocket, docName) {
     try {
-      await setupWSConnection(webSocket, docName, this.env, this.storage, true);
+      await setupWSConnection(webSocket, docName, this.env, this.storage, this.ctx, true);
     } catch (err) {
       logError(err, '[docroom] Error during session setup', docName, err);
       try {
@@ -477,7 +477,7 @@ export class DocRoom {
       // eslint-disable-next-line no-param-reassign
       webSocket.readOnly = true;
     }
-    await handleWebSocketMessage(webSocket, docName, this.env, this.storage, message);
+    await handleWebSocketMessage(webSocket, docName, this.env, this.storage, message, this.ctx);
   }
 
   /**

--- a/src/edge.js
+++ b/src/edge.js
@@ -425,7 +425,7 @@ export class DocRoom {
         auth ? auth.substring(0, auth.indexOf(' ')) : 'none'})`);
 
       // Kick off async document initialization; response is returned immediately.
-      this.initSession(server, docName);
+      this.ctx.waitUntil(this.initSession(server, docName));
 
       const reqHeaders = request.headers;
       const respheaders = new Headers({

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -912,9 +912,9 @@ export const handleWebSocketMessage = async (conn, docName, env, storage, messag
  * @param {WebSocket} conn - The WebSocket connection
  * @param {string} docName - The document name
  */
-export const handleWebSocketClose = (conn, docName) => {
+export const handleWebSocketClose = async (conn, docName) => {
   const doc = docs.get(docName);
   if (doc) {
-    closeConn(doc, conn);
+    await closeConn(doc, conn);
   }
 };

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -903,7 +903,7 @@ export const handleWebSocketMessage = async (conn, docName, env, storage, messag
     doc = docs.get(docName);
   }
   if (doc) {
-    messageListener(conn, doc, new Uint8Array(message));
+    await messageListener(conn, doc, new Uint8Array(message));
   }
 };
 

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -422,7 +422,7 @@ export const persistence = {
    * @param {WebSocket} conn - the websocket connection
    * @param {TransactionalStorage} storage - the worker transactional storage object
    */
-  bindState: async (docName, ydoc, conn, storage) => {
+  bindState: async (docName, ydoc, conn, storage, ctx) => {
     const docType = getDocType(docName);
     let timingReadStateDuration;
 
@@ -485,65 +485,74 @@ export const persistence = {
       // and we must NOT overwrite with the stale da-admin snapshot.
       const svBefore = Y.encodeStateVector(ydoc);
 
-      setTimeout(async () => {
-        if (ydoc === docs.get(docName)) {
-          const svAfter = Y.encodeStateVector(ydoc);
-          const clientHasUpdated = svBefore.length !== svAfter.length
-            || svBefore.some((v, i) => v !== svAfter[i]);
-          if (clientHasUpdated) {
-            // eslint-disable-next-line no-console
-            console.log('[docroom] Skipping da-admin reload: client state received', docName);
-          } else {
-            try {
-              ydoc.transact(() => {
-                if (docType === 'json') {
-                  // Clear JSON structure
-                  const ysheets = ydoc.getArray('sheets');
-                  if (ysheets.length > 0) {
-                    ysheets.delete(0, ysheets.length);
-                  }
-                  // restore from da-admin
-                  json2doc(current, ydoc);
-                } else {
-                  // Clear HTML structure
-                  const rootType = ydoc.getXmlFragment('prosemirror');
-                  rootType.delete(0, rootType.length);
-                  // clear all maps
-                  ydoc.share.forEach((type) => {
-                    if (type instanceof Y.Map) {
-                      type.clear();
-                    }
-                  });
-                  // Restore from da-admin
-                  aem2doc(current, ydoc);
-                }
-              });
-
+      const restoreAfterDelay = new Promise((resolve) => {
+        setTimeout(resolve, 1000);
+      })
+        .then(async () => {
+          if (ydoc === docs.get(docName)) {
+            const svAfter = Y.encodeStateVector(ydoc);
+            const clientHasUpdated = svBefore.length !== svAfter.length
+              || svBefore.some((v, i) => v !== svAfter[i]);
+            if (clientHasUpdated) {
               // eslint-disable-next-line no-console
-              console.log('[docroom] Restored from da-admin', docName, docType);
-            } catch (error) {
-              logError(error, '[docroom] Problem restoring state from da-admin', docName, error, current);
-              if (!isExpectedPlatformEvent(error)) {
-                showError(ydoc, error);
+              console.log('[docroom] Skipping da-admin reload: client state received', docName);
+            } else {
+              try {
+                ydoc.transact(() => {
+                  if (docType === 'json') {
+                    // Clear JSON structure
+                    const ysheets = ydoc.getArray('sheets');
+                    if (ysheets.length > 0) {
+                      ysheets.delete(0, ysheets.length);
+                    }
+                    // restore from da-admin
+                    json2doc(current, ydoc);
+                  } else {
+                    // Clear HTML structure
+                    const rootType = ydoc.getXmlFragment('prosemirror');
+                    rootType.delete(0, rootType.length);
+                    // clear all maps
+                    ydoc.share.forEach((type) => {
+                      if (type instanceof Y.Map) {
+                        type.clear();
+                      }
+                    });
+                    // Restore from da-admin
+                    aem2doc(current, ydoc);
+                  }
+                });
+
+                // eslint-disable-next-line no-console
+                console.log('[docroom] Restored from da-admin', docName, docType);
+              } catch (error) {
+                logError(error, '[docroom] Problem restoring state from da-admin', docName, error, current);
+                if (!isExpectedPlatformEvent(error)) {
+                  showError(ydoc, error);
+                }
+              }
+            }
+
+            // Write lastsync anchor regardless of whether we restored or the client
+            // had already sent updates. CF storage is now anchored to `current`, so
+            // on DO restart we can detect it as a valid continuation even if no PUT
+            // to da-admin has happened yet.
+            if (storage?.put) {
+              try {
+                await storage.put('lastsync', current);
+              } catch (storageErr) {
+                // non-fatal
+                // eslint-disable-next-line no-console
+                console.error('[docroom] Failed to write lastsync after da-admin fetch', storageErr);
               }
             }
           }
+        });
 
-          // Write lastsync anchor regardless of whether we restored or the client
-          // had already sent updates. CF storage is now anchored to `current`, so
-          // on DO restart we can detect it as a valid continuation even if no PUT
-          // to da-admin has happened yet.
-          if (storage?.put) {
-            try {
-              await storage.put('lastsync', current);
-            } catch (storageErr) {
-              // non-fatal
-              // eslint-disable-next-line no-console
-              console.error('[docroom] Failed to write lastsync after da-admin fetch', storageErr);
-            }
-          }
-        }
-      }, 1000);
+      if (ctx?.waitUntil) {
+        ctx.waitUntil(restoreAfterDelay);
+      } else {
+        restoreAfterDelay.catch(() => {});
+      }
     }
 
     ydoc.on('update', async () => {
@@ -675,7 +684,7 @@ export class WSSharedDoc extends Y.Doc {
  * @param {boolean} gc - whether garbage collection is enabled
  * @returns The Yjs document object, which may be shared across multiple sockets.
  */
-export const getYDoc = async (docname, conn, env, storage, timingData, gc = true) => {
+export const getYDoc = async (docname, conn, env, storage, timingData, ctx, gc = true) => {
   let doc = docs.get(docname);
   if (doc === undefined) {
     // The doc is not yet in the cache, create a new one.
@@ -698,7 +707,7 @@ export const getYDoc = async (docname, conn, env, storage, timingData, gc = true
   if (!doc.promise) {
     // The doc is not yet bound to the persistence layer, do so now. The promise will be resolved
     // when bound.
-    doc.promise = persistence.bindState(docname, doc, conn, storage);
+    doc.promise = persistence.bindState(docname, doc, conn, storage, ctx);
   }
 
   // We wait for the promise, for second and subsequent connections to the same doc, this will
@@ -836,7 +845,7 @@ export const invalidateFromAdmin = async (docName) => {
  *   handles message/close routing via class methods instead of addEventListener).
  * @returns {Promise<void>} - The return value of this
  */
-export const setupWSConnection = async (conn, docName, env, storage, hibernation = false) => {
+export const setupWSConnection = async (conn, docName, env, storage, ctx, hibernation = false) => {
   const timingData = new Map();
 
   // eslint-disable-next-line no-param-reassign
@@ -856,7 +865,7 @@ export const setupWSConnection = async (conn, docName, env, storage, hibernation
   }
 
   // get doc, initialize if it does not exist yet
-  const doc = await getYDoc(docName, conn, env, storage, timingData, true);
+  const doc = await getYDoc(docName, conn, env, storage, timingData, ctx, true);
 
   if (!hibernation) {
     // listen and reply to events
@@ -895,11 +904,11 @@ export const setupWSConnection = async (conn, docName, env, storage, hibernation
  * @param {TransactionalStorage} storage - The durable object storage
  * @param {ArrayBuffer|string} message - The raw message from the WebSocket
  */
-export const handleWebSocketMessage = async (conn, docName, env, storage, message) => {
+export const handleWebSocketMessage = async (conn, docName, env, storage, message, ctx) => {
   let doc = docs.get(docName);
   if (!doc) {
     // DO was hibernated; re-establish Yjs state without re-registering event listeners
-    await setupWSConnection(conn, docName, env, storage, true);
+    await setupWSConnection(conn, docName, env, storage, ctx, true);
     doc = docs.get(docName);
   }
   if (doc) {

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -132,29 +132,38 @@ const send = (doc, conn, m) => {
  * @returns {Promise<Uint8Array | undefined>} - The stored state or undefined if not found
  */
 export const readState = async (docName, storage) => {
-  const stored = await storage.list();
-  if (stored.size === 0) {
+  const storedDoc = await storage.get('doc');
+  if (storedDoc === undefined) {
     // eslint-disable-next-line no-console
     console.log('[docroom] No stored doc in persistence');
     return undefined;
   }
 
-  if (stored.get('doc') !== docName) {
+  if (storedDoc !== docName) {
     // eslint-disable-next-line no-console
-    console.log('[docroom] Docname mismatch in persistence. Expected:', docName, 'found:', stored.get('doc'), 'Deleting storage');
+    console.log('[docroom] Docname mismatch in persistence. Expected:', docName, 'found:', storedDoc, 'Deleting storage');
     await storage.deleteAll();
     return undefined;
   }
 
-  if (stored.has('docstore')) {
+  const docstore = await storage.get('docstore');
+  if (docstore !== undefined) {
     // eslint-disable-next-line no-console
     console.log('[docroom] Document found in persistence');
-    return stored.get('docstore');
+    return docstore;
   }
 
+  const chunkCount = await storage.get('chunks');
+  if (chunkCount === undefined) {
+    return undefined;
+  }
+
+  const chunkKeys = Array.from({ length: chunkCount }, (_, i) => `chunk_${i}`);
+  const chunksMap = await storage.get(chunkKeys);
+
   const data = [];
-  for (let i = 0; i < stored.get('chunks'); i += 1) {
-    const chunk = stored.get(`chunk_${i}`);
+  for (let i = 0; i < chunkCount; i += 1) {
+    const chunk = chunksMap.get(`chunk_${i}`);
 
     // Note cannot use the spread operator here, as that goes via the stack and may lead to
     // stack overflow.

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -242,7 +242,7 @@ export const showError = (ydoc, err) => {
 };
 
 export const persistence = {
-  closeConn: closeConn.bind(this),
+  closeConn,
 
   /**
    * Get the document from da-admin.

--- a/test/edge.test.js
+++ b/test/edge.test.js
@@ -1144,7 +1144,7 @@ describe('Worker test suite', () => {
     const m = setYDoc(docName, testYdoc);
 
     const dr = new DocRoom(makeCtx(null), {});
-    dr.webSocketClose(mockConn, 1000, 'Normal', true);
+    await dr.webSocketClose(mockConn, 1000, 'Normal', true);
 
     assert.deepStrictEqual(['close'], closeCalled);
     assert(!m.has(docName), 'Doc should be removed when no connections remain');
@@ -1167,7 +1167,7 @@ describe('Worker test suite', () => {
     const m = setYDoc(docName, testYdoc);
 
     const dr = new DocRoom(makeCtx(null), {});
-    dr.webSocketError(mockConn, new Error('connection reset'));
+    await dr.webSocketError(mockConn, new Error('connection reset'));
 
     assert.deepStrictEqual(['close'], closeCalled);
     assert(!m.has(docName), 'Doc should be removed on error');
@@ -1184,7 +1184,7 @@ describe('Worker test suite', () => {
     };
 
     const dr = new DocRoom(makeCtx(null), {});
-    dr.webSocketClose(mockConn, 1000, 'Normal', true);
+    await dr.webSocketClose(mockConn, 1000, 'Normal', true);
     // No assertion needed — test passes if close() is not called
   });
 

--- a/test/edge.test.js
+++ b/test/edge.test.js
@@ -23,6 +23,7 @@ function makeCtx(storage = null) {
     storage,
     accepted,
     acceptWebSocket(ws) { accepted.push(ws); },
+    waitUntil(p) { return p; },
   };
 }
 

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -494,7 +494,7 @@ describe('Collab Test Suite', () => {
     });
 
     const docName = 'https://admin.da.live/source/reentrant.html';
-    const storage = { list: async () => new Map() };
+    const storage = { list: async () => new Map(), get: async () => undefined };
     const ydoc = new pss.WSSharedDoc(docName);
     pss.setYDoc(docName, ydoc);
 
@@ -757,6 +757,7 @@ describe('Collab Test Suite', () => {
     // Set up bindState which registers update handlers
     const storage = {
       list: async () => new Map(),
+      get: async () => undefined,
       deleteAll: async () => {},
       put: async () => {},
     };
@@ -975,7 +976,7 @@ describe('Collab Test Suite', () => {
     });
 
     const docName = 'https://admin.da.live/source/flush-noop.html';
-    const storage = { list: async () => new Map() };
+    const storage = { list: async () => new Map(), get: async () => undefined };
     const ydoc = new pss.WSSharedDoc(docName);
     pss.setYDoc(docName, ydoc);
 
@@ -1016,7 +1017,7 @@ describe('Collab Test Suite', () => {
     });
 
     const docName = 'https://admin.da.live/source/flush-saves.html';
-    const storage = { list: async () => new Map() };
+    const storage = { list: async () => new Map(), get: async () => undefined };
     const ydoc = new pss.WSSharedDoc(docName);
     pss.setYDoc(docName, ydoc);
 
@@ -1053,7 +1054,7 @@ describe('Collab Test Suite', () => {
     });
 
     const docName = 'https://admin.da.live/source/flush-cancel.html';
-    const storage = { list: async () => new Map() };
+    const storage = { list: async () => new Map(), get: async () => undefined };
     const ydoc = new pss.WSSharedDoc(docName);
     pss.setYDoc(docName, ydoc);
 
@@ -1090,7 +1091,7 @@ describe('Collab Test Suite', () => {
     });
 
     const docName = 'https://admin.da.live/source/flush-inflight.html';
-    const storage = { list: async () => new Map() };
+    const storage = { list: async () => new Map(), get: async () => undefined };
     const ydoc = new pss.WSSharedDoc(docName);
     pss.setYDoc(docName, ydoc);
 
@@ -1188,7 +1189,7 @@ describe('Collab Test Suite', () => {
     };
     pss.setYDoc(docName, testYDoc);
 
-    const mockStorage = { list: () => new Map() };
+    const mockStorage = { list: () => new Map(), get: async () => undefined };
 
     pss.persistence.get = async (nm, au, ad) => `Get: ${nm}-${au}-${ad}`;
     const updated = new Map();
@@ -1225,7 +1226,7 @@ describe('Collab Test Suite', () => {
     };
     pss.setYDoc(docName, testYDoc);
 
-    const mockStorage = { list: () => new Map() };
+    const mockStorage = { list: () => new Map(), get: async () => undefined };
 
     pss.persistence.get = async (nm, au, ad) => `Get: ${nm}-${au}-${ad}`;
     const updated = new Map();
@@ -1262,7 +1263,7 @@ describe('Collab Test Suite', () => {
     };
     pss.setYDoc(docName, testYDoc);
 
-    const mockStorage = { list: () => new Map() };
+    const mockStorage = { list: () => new Map(), get: async () => undefined };
     pss.persistence.get = async (nm, au, ad) => `Get: ${nm}-${au}-${ad}`;
     pss.persistence.update = async () => {};
 
@@ -1300,7 +1301,7 @@ describe('Collab Test Suite', () => {
     };
     pss.setYDoc(docName, testYDoc);
 
-    const mockStorage = { list: () => new Map() };
+    const mockStorage = { list: () => new Map(), get: async () => undefined };
     pss.persistence.get = async (nm, au, ad) => `Get: ${nm}-${au}-${ad}`;
     pss.persistence.update = async () => {};
 
@@ -1335,7 +1336,7 @@ describe('Collab Test Suite', () => {
     };
     pss.setYDoc(docName, testYDoc);
 
-    const mockStorage = { list: () => new Map() };
+    const mockStorage = { list: () => new Map(), get: async () => undefined };
     pss.persistence.get = async (nm, au, ad) => `Get: ${nm}-${au}-${ad}`;
     pss.persistence.update = async () => {};
 
@@ -1370,7 +1371,21 @@ describe('Collab Test Suite', () => {
     // Create a new YDoc which will be initialised from storage
     const ydoc = new Y.Doc();
     const conn = {};
-    const storage = { list: async () => stored };
+    const storage = {
+      list: async () => stored,
+      get: async (keyOrKeys) => {
+        if (Array.isArray(keyOrKeys)) {
+          const result = new Map();
+          keyOrKeys.forEach((k) => {
+            if (stored.has(k)) {
+              result.set(k, stored.get(k));
+            }
+          });
+          return result;
+        }
+        return stored.get(keyOrKeys);
+      },
+    };
 
     const savedGet = persistence.get;
     try {
@@ -1407,7 +1422,21 @@ describe('Collab Test Suite', () => {
 
     const ydoc = new Y.Doc();
     const conn = {};
-    const storage = { list: async () => stored };
+    const storage = {
+      list: async () => stored,
+      get: async (keyOrKeys) => {
+        if (Array.isArray(keyOrKeys)) {
+          const result = new Map();
+          keyOrKeys.forEach((k) => {
+            if (stored.has(k)) {
+              result.set(k, stored.get(k));
+            }
+          });
+          return result;
+        }
+        return stored.get(keyOrKeys);
+      },
+    };
 
     const savedGet = persistence.get;
     try {
@@ -1433,6 +1462,9 @@ describe('Collab Test Suite', () => {
 
     const storage = {
       list: async () => {
+        throw new Error('yikes');
+      },
+      get: async () => {
         throw new Error('yikes');
       },
     };
@@ -1470,7 +1502,7 @@ describe('Collab Test Suite', () => {
     });
 
     const docName = 'https://admin.da.live/source/foo/bar.html';
-    const storage = { list: async () => new Map() };
+    const storage = { list: async () => new Map(), get: async () => undefined };
     const updObservers = [];
     const ydoc = new Y.Doc();
     ydoc.on = (ev, fun) => {
@@ -1531,7 +1563,7 @@ describe('Collab Test Suite', () => {
     });
 
     const docName = 'https://admin.da.live/source/foo/bar.html';
-    const storage = { list: async () => new Map() };
+    const storage = { list: async () => new Map(), get: async () => undefined };
     const updObservers = [];
     const ydoc = new Y.Doc();
     ydoc.on = (ev, fun) => {
@@ -2084,30 +2116,61 @@ describe('Collab Test Suite', () => {
     assert.equal(1, decoding.readVarUint(decoder), 'ok must be 1 when no flushSave (nothing to flush)');
   });
 
+  function makeStorage(data = {}) {
+    const map = new Map(Object.entries(data));
+    return {
+      async list() { return map; },
+      async get(keyOrKeys) {
+        if (Array.isArray(keyOrKeys)) {
+          const result = new Map();
+          keyOrKeys.forEach((k) => {
+            if (map.has(k)) {
+              result.set(k, map.get(k));
+            }
+          });
+          return result;
+        }
+        return map.get(keyOrKeys);
+      },
+      async put(d) { Object.entries(d).forEach(([k, v]) => map.set(k, v)); },
+      async delete(keys) {
+        (Array.isArray(keys) ? keys : [keys]).forEach((k) => map.delete(k));
+      },
+      async deleteAll() { map.clear(); },
+    };
+  }
+
   it('readState not chunked', async () => {
     const docName = 'http://foo.bar/doc123.html';
-    const stored = new Map();
-    stored.set('docstore', new Uint8Array([254, 255]));
-    stored.set('chunks', 17); // should be ignored
-    stored.set('doc', docName);
-
-    const storage = { list: async () => stored };
+    const storage = makeStorage({
+      docstore: new Uint8Array([254, 255]),
+      chunks: 17, // should be ignored
+      doc: docName,
+    });
 
     const data = await readState(docName, storage);
     assert.deepStrictEqual(new Uint8Array([254, 255]), data);
   });
 
+  it('readState no stored doc returns undefined', async () => {
+    const storage = makeStorage({});
+
+    const data = await readState('http://foo.bar/doc123.html', storage);
+    assert.equal(data, undefined);
+  });
+
   it('readState doc mismatch', async () => {
     const docName = 'http://foo.bar/doc123.html';
-    const stored = new Map();
-    stored.set('docstore', new Uint8Array([254, 255]));
-    stored.set('chunks', 17); // should be ignored
-    stored.set('doc', 'http://foo.bar/doc456.html');
-
     const storageCalled = [];
-    const storage = {
-      list: async () => stored,
-      deleteAll: async () => storageCalled.push('deleteAll'),
+    const storage = makeStorage({
+      docstore: new Uint8Array([254, 255]),
+      chunks: 17, // should be ignored
+      doc: 'http://foo.bar/doc456.html',
+    });
+    const origDeleteAll = storage.deleteAll.bind(storage);
+    storage.deleteAll = async () => {
+      storageCalled.push('deleteAll');
+      return origDeleteAll();
     };
 
     const data = await readState(docName, storage);
@@ -2116,13 +2179,12 @@ describe('Collab Test Suite', () => {
   });
 
   it('readState chunked', async () => {
-    const stored = new Map();
-    stored.set('chunk_0', new Uint8Array([1, 2, 3]));
-    stored.set('chunk_1', new Uint8Array([4, 5]));
-    stored.set('chunks', 2);
-    stored.set('doc', 'mydoc');
-
-    const storage = { list: async () => stored };
+    const storage = makeStorage({
+      chunk_0: new Uint8Array([1, 2, 3]),
+      chunk_1: new Uint8Array([4, 5]),
+      chunks: 2,
+      doc: 'mydoc',
+    });
 
     const data = await readState('mydoc', storage);
     assert.deepStrictEqual(new Uint8Array([1, 2, 3, 4, 5]), data);
@@ -2369,7 +2431,21 @@ describe('Collab Test Suite', () => {
     const conn = {};
     const storage = {
       list: async () => stored,
-      get: async (key) => (key === 'lastsync' ? daAdminContent : undefined),
+      get: async (keyOrKeys) => {
+        if (Array.isArray(keyOrKeys)) {
+          const result = new Map();
+          keyOrKeys.forEach((k) => {
+            if (stored.has(k)) {
+              result.set(k, stored.get(k));
+            }
+          });
+          return result;
+        }
+        if (keyOrKeys === 'lastsync') {
+          return daAdminContent;
+        }
+        return stored.get(keyOrKeys);
+      },
     };
 
     const savedSetTimeout = globalThis.setTimeout;
@@ -2585,7 +2661,7 @@ describe('Collab Test Suite', () => {
     });
 
     const docName = 'https://admin.da.live/source/skip-save.html';
-    const storage = { list: async () => new Map() };
+    const storage = { list: async () => new Map(), get: async () => undefined };
     const updObservers = [];
     const ydoc = new pss.WSSharedDoc(docName);
     const originalOn = ydoc.on.bind(ydoc);

--- a/test/stubs/cloudflare-workers-hook.mjs
+++ b/test/stubs/cloudflare-workers-hook.mjs
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === 'cloudflare:workers') {
+    return {
+      shortCircuit: true,
+      url: new URL('./cloudflare-workers.js', import.meta.url).href,
+      format: 'module',
+    };
+  }
+  return nextResolve(specifier, context);
+}

--- a/test/stubs/cloudflare-workers.js
+++ b/test/stubs/cloudflare-workers.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// Stub for cloudflare:workers in the Node.js test environment
+export class DurableObject {
+  constructor(ctx, env) {
+    this.ctx = ctx;
+    this.env = env;
+  }
+}

--- a/test/stubs/register.mjs
+++ b/test/stubs/register.mjs
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { register } from 'node:module';
+
+register(
+  new URL('./cloudflare-workers-hook.mjs', import.meta.url).href,
+  import.meta.url,
+);

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,6 +9,10 @@ port = 4711
 
 [[migrations]]
 tag = "v1" # Should be unique for each entry
+# DocRoom uses the legacy KV-backed storage. Cloudflare now recommends
+# new_sqlite_classes for new Durable Object namespaces (SQLite-backed DOs
+# support SQL queries and 30-day point-in-time recovery). Migrating existing
+# instances requires a v2 migration tag, a new class, and a data migration.
 new_classes = ["DocRoom"]
 
 # ----------------------------------------------------------------------

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
 name = "da-collab"
 workers_dev = true
-compatibility_date = "2023-10-30"
+compatibility_date = "2024-04-03"
 main = "src/edge.js"
 keep_vars = true
 


### PR DESCRIPTION
Consolidates all Durable Object best-practice fixes into a single reviewable PR. Replaces #163, #164, #165, #166, #167, #168, #169, #170, #171.

## Changes

### High severity — data correctness
- **#163** `ctx.waitUntil(initSession(...))` — prevents the DO from being evicted before async session setup completes
- **#165** `webSocketClose` / `webSocketError` made async — ensures `flushSave` is awaited on last disconnect, preventing silent data loss
- **#166** `await messageListener(...)` in `handleWebSocketMessage` — flush ack is no longer sent before the save completes

### Medium severity — modernisation
- **#167** `DocRoom` extends `DurableObject` base class — prerequisite for RPC; adds `cloudflare:workers` stub so the Mocha test suite keeps working
- **#168** `compatibility_date` bumped to `2024-04-03` — minimum date to enable RPC on DO stubs

### Low severity — correctness and performance
- **#170** `setTimeout` for deferred da-admin reload replaced with `ctx.waitUntil(promise)` — timer now survives DO hibernation; `ctx` threaded through `setupWSConnection` → `getYDoc` → `bindState`
- **#171** `closeConn.bind(this)` → `closeConn` — `this` is `undefined` at module scope in strict mode; the bind was a no-op
- **#164** `readState` uses targeted `storage.get()` calls instead of `storage.list()` — avoids loading the full document (potentially MBs of chunks) in the "not found" and "name mismatch" cold-start cases
- **#169** Wrangler migration comment documenting the SQLite upgrade path for `DocRoom`

## Test plan
- All 155 tests pass on the merged branch (`npm test`)
- One conflict was resolved manually: `initSession` and `webSocketMessage` in `DocRoom` now correctly combine `this.ctx?.storage` (from #167) with the new `ctx` parameter (from #170)

🤖 Generated with [Claude Code](https://claude.com/claude-code)