### PR TITLE
fix: prevent bindState hang and auto-repair stale CF storage

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,6 +18,7 @@ export default defineConfig([
     'coverage',
     'dist/*',
     '.wrangler',
+    '.claude',
   ]),
   {
     languageOptions: {

--- a/src/edge.js
+++ b/src/edge.js
@@ -331,7 +331,7 @@ export class DocRoom extends DurableObject {
    * @param {Request} request
    * @returns {Promise<*>}
    */
-  // eslint-disable-next-line class-methods-use-this,no-unused-vars
+  // eslint-disable-next-line no-unused-vars
   async handleApiCall(api, docName, request) {
     switch (api) {
       case 'deleteAdmin':
@@ -346,6 +346,16 @@ export class DocRoom extends DurableObject {
         } else {
           return new Response('Not Found', { status: 404 });
         }
+      case 'clearStorage':
+        // Wipe all CF DO storage for this document (ydoc state + lastsync anchor).
+        // Required when the stored ydoc state is corrupted and causes doc2aem to hang,
+        // making bindState never complete. After clearing, the next connection will
+        // fall back to da-admin content via the !restored path in bindState.
+        if (this.ctx?.storage) {
+          await this.ctx.storage.deleteAll();
+        }
+        await invalidateFromAdmin(docName);
+        return new Response('OK', { status: 200 });
       default:
         return new Response('Invalid API', { status: 400 });
     }

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -500,22 +500,23 @@ export const persistence = {
       if (stored && stored.length > 0) {
         Y.applyUpdate(ydoc, stored);
 
-        // CF storage is valid to use if:
-        // 1. Its rendered content matches da-admin exactly (nothing pending), OR
-        // 2. da-admin still has the same content as the last successful sync —
-        //    meaning CF storage is ahead of da-admin (unsaved pending changes) but
-        //    was built on top of it. Using CF storage preserves those pending changes.
-        //    This correctly handles DO migration while a debounced save is in flight.
-        //    If da-admin was externally modified since the last sync, lastSynced !==
-        //    current, so we fall back to da-admin (external edit wins).
-        const fromStorage = docType === 'json' ? doc2json(ydoc) : doc2aem(ydoc);
+        // CF storage is valid to use if da-admin still has the same content as the
+        // last successful sync — meaning CF storage is either in sync with or ahead
+        // of da-admin (unsaved pending changes built on top of it).
+        // Using CF storage preserves those pending changes.
+        // If da-admin was externally modified since the last sync, lastSynced !==
+        // current, so we fall back to da-admin (external edit wins).
+        //
+        // NOTE: we intentionally do NOT call doc2aem/doc2json here. Those are
+        // synchronous serialisers that can block the CF event loop for an extended
+        // time when the stored ydoc state is large or structurally unexpected,
+        // causing the DO to be terminated before bindState completes.
+        // The lastsync anchor alone is sufficient to determine validity.
         const lastSynced = storage.get ? await storage.get('lastsync') : undefined;
-        if (fromStorage === current || lastSynced === current) {
+        if (lastSynced === current) {
           restored = true;
-
-          const syncState = fromStorage === current ? '(in sync with da-admin)' : '(has pending unsaved changes)';
           // eslint-disable-next-line no-console
-          console.log('[docroom] Restored from worker persistence', docName, syncState);
+          console.log('[docroom] Restored from worker persistence', docName, '(lastsync matches da-admin)');
         }
       }
     } catch (error) {
@@ -526,9 +527,12 @@ export const persistence = {
     }
 
     if (!restored && current) {
-      // The doc was not restored from worker persistence, so read it from da-admin,
-      // but do this async to give the ydoc some time to get synced up first. Without
-      // this timeout, the ydoc can get confused which may result in duplicated content.
+      // The doc was not restored from worker persistence, so read it from da-admin.
+      // Clear stale CF storage so the next save writes clean state instead of
+      // accumulating diverged CRDT updates that can cause future bindState hangs.
+      if (storage.deleteAll) {
+        await storage.deleteAll();
+      }
       // eslint-disable-next-line no-console
       console.log('[docroom] Could not be restored, trying to restore from da-admin', docName);
 

--- a/test/edge.test.js
+++ b/test/edge.test.js
@@ -302,6 +302,53 @@ describe('Worker test suite', () => {
     assert.equal(400, resp.status);
   });
 
+  it('Docroom clearStorage deletes all CF storage and closes connections', async () => {
+    const ydocName = 'http://foobar.com/clearstorage-test.html';
+    const testYdoc = new WSSharedDoc(ydocName);
+    const m = setYDoc(ydocName, testYdoc);
+
+    const connClosed = [];
+    const mockConn = { close() { connClosed.push('close'); } }; // eslint-disable-line max-statements-per-line
+    testYdoc.conns.set(mockConn, 1234);
+
+    const deleteCalled = [];
+    const mockStorage = {
+      async deleteAll() { deleteCalled.push(true); },
+    };
+
+    const req = { url: `${ydocName}?api=clearStorage` };
+    const dr = new DocRoom({ storage: mockStorage });
+
+    assert(m.has(ydocName), 'Precondition: doc must be registered');
+    const resp = await dr.fetch(req);
+    assert.equal(200, resp.status);
+    assert.deepStrictEqual(deleteCalled, [true], 'storage.deleteAll() must be called');
+    assert(!m.has(ydocName), 'Doc should have been removed from docs map');
+    assert.deepStrictEqual(connClosed, ['close'], 'Active connections should be closed');
+    testYdoc.destroy();
+  });
+
+  it('Docroom clearStorage without active doc still clears storage', async () => {
+    const deleteCalled = [];
+    const mockStorage = {
+      async deleteAll() { deleteCalled.push(true); },
+    };
+    const dr = new DocRoom({ storage: mockStorage });
+
+    const req = { url: 'http://foobar.com/no-doc.html?api=clearStorage' };
+    const resp = await dr.fetch(req);
+
+    assert.equal(200, resp.status, 'clearStorage returns 200 even when doc is not in memory');
+    assert.deepStrictEqual(deleteCalled, [true], 'storage.deleteAll() must still be called');
+  });
+
+  it('Docroom clearStorage with no storage context still returns 200', async () => {
+    const dr = new DocRoom({});
+    const req = { url: 'http://foobar.com/no-storage.html?api=clearStorage' };
+    const resp = await dr.fetch(req);
+    assert.equal(200, resp.status);
+  });
+
   it('Test DocRoom fetch', async () => {
     const savedNWSP = DocRoom.newWebSocketPair;
     const savedBS = persistence.bindState;

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -2468,6 +2468,57 @@ describe('Collab Test Suite', () => {
     }
   });
 
+  it('bindState clears stale CF storage when lastsync does not match da-admin', async () => {
+    const docName = 'https://admin.da.live/source/foo/stale.html';
+    const daAdminContent = '<body>\n  <header></header>\n  <main><div><p>current</p></div></main>\n  <footer></footer>\n</body>\n';
+
+    // CF storage has state from an older da-admin version
+    const staleDoc = new Y.Doc();
+    aem2doc('<body>\n  <header></header>\n  <main><div><p>stale</p></div></main>\n  <footer></footer>\n</body>\n', staleDoc);
+    const staleState = Y.encodeStateAsUpdate(staleDoc);
+
+    const deleteAllCalled = [];
+    const stored = new Map([
+      ['doc', docName],
+      ['docstore', staleState],
+      // lastsync is intentionally absent → lastsync !== current → !restored
+    ]);
+    const storage = {
+      list: async () => stored,
+      get: async (keyOrKeys) => {
+        if (Array.isArray(keyOrKeys)) {
+          const result = new Map();
+          keyOrKeys.forEach((k) => {
+            if (stored.has(k)) {
+              result.set(k, stored.get(k));
+            }
+          });
+          return result;
+        }
+        return stored.get(keyOrKeys);
+      },
+      deleteAll: async () => { deleteAllCalled.push(true); },
+    };
+
+    const ydoc = new Y.Doc();
+    setYDoc(docName, ydoc);
+    const conn = {};
+
+    const savedSetTimeout = globalThis.setTimeout;
+    const savedGet = persistence.get;
+    try {
+      globalThis.setTimeout = () => {}; // suppress async da-admin restore
+      persistence.get = async () => daAdminContent;
+
+      await persistence.bindState(docName, ydoc, conn, storage);
+
+      assert.deepStrictEqual(deleteAllCalled, [true], 'storage.deleteAll() must be called to clear stale CF storage');
+    } finally {
+      globalThis.setTimeout = savedSetTimeout;
+      persistence.get = savedGet;
+    }
+  });
+
   it('bindState writes lastsync after initial da-admin restore so a later DO reset can recover pending changes', async () => {
     const docName = 'https://admin.da.live/source/foo/bar.html';
     const daAdminContent = '<body>\n  <header></header>\n  <main><div><p>synced</p></div></main>\n  <footer></footer>\n</body>\n';


### PR DESCRIPTION
## Summary

- **Remove `doc2aem`/`doc2json` from `bindState`**: these synchronous serialisers were called on the stored CF ydoc state to validate it before use. When the state is large or structurally unexpected (accumulated CRDT history from heavy editing), they block the CF event loop until the DO is terminated — leaving clients stuck receiving only awareness messages with no sync ever happening. The `lastsync` anchor alone is sufficient: if `lastsync === current` (da-admin hash), the CF state is valid.

- **Auto-clear stale CF storage when falling back to da-admin**: when `lastsync` does not match `current`, the stored CRDT is diverged from da-admin. We now call `storage.deleteAll()` before restoring from da-admin so the next save writes clean state instead of keeping the accumulated diverged updates that trigger the hang on the next hibernation wake-up. This makes stuck documents self-healing — no manual `clearStorage` calls needed.

- **Add `clearStorage` API on `DocRoom`**: emergency escape hatch to wipe CF DO storage and close connections for a stuck document via `?api=clearStorage`, without waiting for a da-admin content change to trigger the auto-repair path.

- **Ignore `.claude` worktrees in ESLint config**: agent worktrees were being linted, producing spurious errors.

## Root cause (incident)

Documents `/adobecom/da-bacom/{uk,jp,pt}/fragments/homepage/cannes-solution-pods` were stuck: every WS connect logged only "Setting up WSConnection" + "Getting ydoc", then the DO was killed silently. The documents had large chunked CF ydoc state from a localization job; `doc2aem` on that state hung the event loop. After this fix, those documents self-repair on the next connection because the localization job updated da-admin (`lastsync !== current` → auto-clear → fresh load from da-admin).

## Test plan

- [ ] `npm test` — all tests pass (163 tests, 0 failures)
- [ ] `npm run lint` — no errors
- [ ] Verify stuck locale documents (`uk`, `jp`, `pt`) load correctly after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)