### PR TITLE
fix(docroom): guard lastsync writes against DO 128 KiB value cap

### DIFF
--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -92,6 +92,31 @@ export const messageFlushRequest = 2;
 export const messageFlushResponse = 3;
 const MAX_STORAGE_KEYS = 128;
 const MAX_STORAGE_VALUE_SIZE = 131072;
+
+/**
+ * Write the `lastsync` marker to Durable Object storage, guarded against the
+ * 128 KiB per-value cap. Cloudflare DO storage throws `RangeError` for any
+ * value larger than `MAX_STORAGE_VALUE_SIZE` — that is platform-deterministic,
+ * so we skip the write at `console.log` level rather than surfacing it as
+ * `console.error` noise. The absence of `lastsync` already triggers the
+ * documented da-admin restore fallback on DO restart, so skipping is safe.
+ */
+export const safePutLastsync = async (storage, value, docName, context) => {
+  if (!storage?.put) {
+    return;
+  }
+  if (value.length > MAX_STORAGE_VALUE_SIZE) {
+    // eslint-disable-next-line no-console
+    console.log(`[docroom] Skipping lastsync marker (${context}) - content exceeds DO value cap`, docName, `${value.length}b`);
+    return;
+  }
+  try {
+    await storage.put('lastsync', value);
+  } catch (storageErr) {
+    // non-fatal: worst case the restore falls back to da-admin
+    logError(storageErr, `[docroom] Failed to write lastsync (${context})`, storageErr);
+  }
+};
 // Matches da-admin EMPTY_DOC_SIZE — the byte-length of doc2aem(empty ydoc).
 // PUTs at or below this size are the deterministic empty stub; allowing one
 // through when no client edit happened silently overwrites real customer content
@@ -432,15 +457,7 @@ export const persistence = {
         // Record what we just PUT so that on DO restart we can tell whether
         // CF storage is ahead of da-admin (safe to use) vs. da-admin was
         // externally modified (must use da-admin).
-        if (ydoc.storage?.put) {
-          try {
-            await ydoc.storage.put('lastsync', content);
-          } catch (storageErr) {
-            // non-fatal: worst case the restore falls back to da-admin
-            // eslint-disable-next-line no-console
-            console.error('[docroom] Failed to write lastsync marker', storageErr);
-          }
-        }
+        await safePutLastsync(ydoc.storage, content, docName, 'after da-admin PUT');
         return content;
       }
     } catch (err) {
@@ -593,15 +610,7 @@ export const persistence = {
             // had already sent updates. CF storage is now anchored to `current`, so
             // on DO restart we can detect it as a valid continuation even if no PUT
             // to da-admin has happened yet.
-            if (storage?.put) {
-              try {
-                await storage.put('lastsync', current);
-              } catch (storageErr) {
-                // non-fatal
-                // eslint-disable-next-line no-console
-                console.error('[docroom] Failed to write lastsync after da-admin fetch', storageErr);
-              }
-            }
+            await safePutLastsync(storage, current, docName, 'after da-admin fetch');
           }
         });
 

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -23,7 +23,8 @@ import {
   closeConn, getBackend, getYDoc, isHelixDoc,
   invalidateFromAdmin, isExpectedPlatformEvent, messageFlushRequest,
   messageFlushResponse, messageListener, persistence,
-  readState, setupWSConnection, setYDoc, showError, storeState, updateHandler, WSSharedDoc,
+  readState, safePutLastsync, setupWSConnection, setYDoc,
+  showError, storeState, updateHandler, WSSharedDoc,
 } from '../src/shareddoc.js';
 
 function isSubArray(full, sub) {
@@ -2553,6 +2554,217 @@ describe('Collab Test Suite', () => {
       assert.equal(1, lastsyncPuts.length, 'lastsync should be written exactly once');
       assert.equal(daAdminContent, lastsyncPuts[0][1], 'lastsync value must equal the da-admin content');
     } finally {
+      globalThis.setTimeout = savedSetTimeout;
+      persistence.get = savedGet;
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // safePutLastsync helper + size-cap guard at both call sites
+  //
+  // Durable Object storage rejects values > 131072 bytes with a RangeError.
+  // This used to surface as `[docroom] Failed to write lastsync …` console.error
+  // at both call sites (`persistence.update` after da-admin PUT, and
+  // `persistence.bindState` after the da-admin restore fetch). The helper
+  // skips the put for oversize content and logs the skip at log-level. The
+  // absence of the `lastsync` key is already the documented trigger for the
+  // da-admin restore fallback, so skipping is safe.
+  // ---------------------------------------------------------------------------
+
+  it('safePutLastsync skips put + logs at log-level when value exceeds DO value cap', async () => {
+    const oversize = `<body>${'x'.repeat(140 * 1024)}</body>`;
+    assert(oversize.length > 131072, 'Precondition: oversize > 131072 bytes');
+
+    const putCalls = [];
+    const storage = {
+      put: async (...args) => {
+        putCalls.push(args);
+        throw new RangeError(
+          `Values cannot be larger than 131072 bytes. A value of size ${args[1].length} was provided.`,
+        );
+      },
+    };
+
+    const errors = [];
+    const logs = [];
+    const savedError = console.error;
+    const savedLog = console.log;
+    console.error = (...args) => errors.push(args);
+    console.log = (...args) => logs.push(args);
+
+    try {
+      await safePutLastsync(storage, oversize, 'oversize-doc.html', 'unit-test');
+
+      assert.equal(0, putCalls.length, 'storage.put must not be called for oversize value');
+      assert.equal(0, errors.filter(
+        (args) => typeof args[0] === 'string' && args[0].includes('Failed to write lastsync'),
+      ).length, 'No console.error must fire for the platform-deterministic size cap');
+      const skipLog = logs.find(
+        (args) => typeof args[0] === 'string' && args[0].includes('Skipping lastsync marker'),
+      );
+      assert(skipLog, 'A console.log explaining the skip should fire');
+      assert(skipLog[0].includes('unit-test'), 'Skip log should include the call-site context');
+    } finally {
+      console.error = savedError;
+      console.log = savedLog;
+    }
+  });
+
+  it('safePutLastsync writes once when value fits the DO value cap', async () => {
+    const small = 'small content';
+    const putCalls = [];
+    const storage = { put: async (...args) => putCalls.push(args) };
+
+    await safePutLastsync(storage, small, 'small-doc.html', 'unit-test');
+
+    assert.equal(1, putCalls.length, 'storage.put must be called for in-cap value');
+    assert.equal('lastsync', putCalls[0][0], 'key must be lastsync');
+    assert.equal(small, putCalls[0][1], 'value must equal the input');
+  });
+
+  it('safePutLastsync is a no-op when storage has no .put method', async () => {
+    // Should not throw, regardless of value size.
+    await safePutLastsync(undefined, 'whatever', 'no-storage.html', 'unit-test');
+    await safePutLastsync({}, 'whatever', 'no-storage.html', 'unit-test');
+  });
+
+  it('persistence.update skips lastsync put when saved content exceeds DO value cap', async () => {
+    const oversize = `<body>${'y'.repeat(140 * 1024)}</body>`;
+    assert(oversize.length > 131072, 'Precondition: oversize > 131072 bytes');
+
+    const pss = await esmock('../src/shareddoc.js', {
+      '@da-tools/da-parser': {
+        doc2aem: () => oversize,
+      },
+    });
+
+    const putCalls = [];
+    const mockYDoc = {
+      conns: { keys() { return [{}]; } },
+      name: 'http://foo.bar/0/oversize-save.html',
+      hasClientChanged: true,
+      storage: {
+        put: async (...args) => {
+          putCalls.push(args);
+          throw new RangeError(
+            `Values cannot be larger than 131072 bytes. A value of size ${args[1].length} was provided.`,
+          );
+        },
+      },
+    };
+
+    pss.persistence.put = async () => ({ ok: true, status: 200, statusText: 'OK' });
+
+    const errors = [];
+    const logs = [];
+    const savedError = console.error;
+    const savedLog = console.log;
+    console.error = (...args) => errors.push(args);
+    console.log = (...args) => logs.push(args);
+
+    try {
+      const result = await pss.persistence.update(mockYDoc, 'old content', 'oversize-save.html');
+      assert.equal(oversize, result);
+
+      const lastsyncPuts = putCalls.filter(([key]) => key === 'lastsync');
+      assert.equal(0, lastsyncPuts.length, 'lastsync put must be skipped for oversize content');
+      assert.equal(0, errors.filter(
+        (args) => typeof args[0] === 'string' && args[0].includes('Failed to write lastsync'),
+      ).length, 'No console.error for the platform-deterministic size cap');
+      assert(logs.find(
+        (args) => typeof args[0] === 'string' && args[0].includes('Skipping lastsync marker'),
+      ), 'console.log skip message must fire');
+    } finally {
+      console.error = savedError;
+      console.log = savedLog;
+    }
+  });
+
+  it('persistence.update still writes lastsync when saved content fits the DO value cap', async () => {
+    const small = 'new content';
+    const pss = await esmock('../src/shareddoc.js', {
+      '@da-tools/da-parser': {
+        doc2aem: () => small,
+      },
+    });
+
+    const putCalls = [];
+    const mockYDoc = {
+      conns: { keys() { return [{}]; } },
+      name: 'http://foo.bar/0/small-save.html',
+      hasClientChanged: true,
+      storage: {
+        put: async (...args) => putCalls.push(args),
+      },
+    };
+
+    pss.persistence.put = async () => ({ ok: true, status: 200, statusText: 'OK' });
+
+    const result = await pss.persistence.update(mockYDoc, 'old content', 'small-save.html');
+    assert.equal(small, result);
+
+    const lastsyncPuts = putCalls.filter(([key]) => key === 'lastsync');
+    assert.equal(1, lastsyncPuts.length, 'lastsync must be written for in-cap content');
+    assert.equal(small, lastsyncPuts[0][1]);
+  });
+
+  it('bindState after da-admin fetch skips lastsync put when content exceeds DO value cap', async () => {
+    const docName = 'https://admin.da.live/source/foo/oversize.html';
+    const oversize = `<body>${'z'.repeat(140 * 1024)}</body>`;
+    assert(oversize.length > 131072, 'Precondition: oversize > 131072 bytes');
+
+    const ydoc = new Y.Doc();
+    setYDoc(docName, ydoc);
+    const conn = {};
+
+    const putCalls = [];
+    const storage = {
+      list: async () => new Map(),
+      get: async () => undefined,
+      put: async (...args) => {
+        putCalls.push(args);
+        throw new RangeError(
+          `Values cannot be larger than 131072 bytes. A value of size ${args[1].length} was provided.`,
+        );
+      },
+    };
+
+    const errors = [];
+    const logs = [];
+    const savedError = console.error;
+    const savedLog = console.log;
+    console.error = (...args) => errors.push(args);
+    console.log = (...args) => logs.push(args);
+
+    const savedSetTimeout = globalThis.setTimeout;
+    const savedGet = persistence.get;
+    try {
+      let timeoutFn;
+      globalThis.setTimeout = (f) => {
+        timeoutFn = f;
+      };
+      persistence.get = async () => oversize;
+
+      await persistence.bindState(docName, ydoc, conn, storage);
+      assert(timeoutFn, 'setTimeout callback should have been registered');
+
+      await timeoutFn();
+      // The .then chain after the timeout resolves contains an awaited
+      // safePutLastsync; wait two microtasks to give it time to settle.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const lastsyncPuts = putCalls.filter(([key]) => key === 'lastsync');
+      assert.equal(0, lastsyncPuts.length, 'lastsync put must be skipped for oversize content');
+      assert.equal(0, errors.filter(
+        (args) => typeof args[0] === 'string' && args[0].includes('Failed to write lastsync'),
+      ).length, 'No console.error for the platform-deterministic size cap');
+      assert(logs.find(
+        (args) => typeof args[0] === 'string' && args[0].includes('Skipping lastsync marker'),
+      ), 'console.log skip message must fire');
+    } finally {
+      console.error = savedError;
+      console.log = savedLog;
       globalThis.setTimeout = savedSetTimeout;
       persistence.get = savedGet;
     }


### PR DESCRIPTION
## Summary

Durable Object storage rejects values > 131072 bytes with a `RangeError`. Both `lastsync` writes in `src/shareddoc.js` — `persistence.update` after a successful da-admin PUT, and `persistence.bindState` after the da-admin restore fetch — used to call `storage.put('lastsync', …)` unconditionally and surface the platform-deterministic throw as `[docroom] Failed to write lastsync …` `console.error` noise (sustained 2 events / 24h on the `da-collab` error stream, two distinct payload sizes per day).

Introduce a small `safePutLastsync(storage, value, docName, context)` helper that:

- Skips the put entirely when `value.length > MAX_STORAGE_VALUE_SIZE`, logging the skip at `console.log` level so it stays out of the error channel.
- Routes any other exception class through `logError(...)`, so the existing demotion path for `isExpectedPlatformEvent` (DO live migration / worker upgrade events) still applies.

Both call sites delegate to the helper, so any future lastsync write inherits the guard for free.

## Why

The 128 KiB cap is platform-deterministic in the same way that the live-migration error is — there is no point landing it in `console.error`. The pre-existing try/catch comment promised _"non-fatal: worst case the restore falls back to da-admin"_; in practice that fallback was already taking effect (the marker was skipped after the throw), but the throw was producing log noise on the error channel for every oversize save. Skipping is safe because the absence of the `lastsync` key is already the documented trigger for the da-admin restore on DO restart.

The pattern matches the demotions shipped in #135 / #155 / #157 for the live-migration / upgrade events.

## Test plan

- [x] Failing-test-first: new mocha cases in `test/shareddoc.test.js` mock a storage stub that throws the production `RangeError` shape (`Values cannot be larger than 131072 bytes. A value of size <N> was provided.`). Both `persistence.update` and `persistence.bindState` integration cases for oversize content were verified to fail against an inline-revert of the call-site updates before the guard was applied.
- [x] After the fix: `npx mocha --reporter spec --import=./test/stubs/register.mjs --exit test/*.test.js` — **165 passing, 0 regressions**.
- [x] Direct helper tests cover oversize, in-cap, and no-storage cases.
- [x] `npm run lint` — clean.
- [ ] Post-deploy: confirm `m.contains('Values cannot be larger than')` errors at `$d.ScriptName == 'da-collab'`, `l.Level == 'error'` return to 0 / 24h × 3 consecutive days.

## Scope notes

- No change in lastsync semantics for ≤ 128 KiB content — the existing "preserve pending Yjs changes across DO evictions" guarantee is preserved (verified by the existing `bindState writes lastsync …` test, which still passes unchanged).
- Not addressing whether oversize documents should chunk the marker — current behavior (rely on da-admin restore fallback) is unchanged.
