### PR TITLE
fix(docroom): demote 401/403 from da-admin to non-error logs

### DIFF
--- a/src/edge.js
+++ b/src/edge.js
@@ -463,7 +463,17 @@ export class DocRoom {
     try {
       await setupWSConnection(webSocket, docName, this.env, this.storage, true);
     } catch (err) {
-      logError(err, '[docroom] Error during session setup', docName, err);
+      // 401/403 from da-admin are auth/ACL outcomes the worker cannot bypass —
+      // operational noise, not service errors. Mirrors persistence.get/update.
+      if (err?.status === 401) {
+        // eslint-disable-next-line no-console
+        console.warn('[docroom] Error during session setup', docName, err.message);
+      } else if (err?.status === 403) {
+        // eslint-disable-next-line no-console
+        console.log('[docroom] Error during session setup', docName, err.message);
+      } else {
+        logError(err, '[docroom] Error during session setup', docName, err);
+      }
       try {
         webSocket.close(1011, err.message);
       } catch (_) { /* already closed */ }

--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -305,8 +305,20 @@ export const persistence = {
     if (initialReq.ok) {
       return docType === 'json' ? initialReq.json() : initialReq.text();
     } else {
-      // eslint-disable-next-line no-console
-      console.error(`[docroom] Unable to get resource from da-admin: ${initialReq.status} - ${initialReq.statusText}`);
+      const msg = `[docroom] Unable to get resource from da-admin: ${initialReq.status} - ${initialReq.statusText}`;
+      // 401/403 are auth/ACL outcomes the worker cannot bypass — operational
+      // noise, not service errors. Mirror persistence.update's PUT demotion so
+      // the error stream stays a real-signal channel (see #135).
+      if (initialReq.status === 401) {
+        // eslint-disable-next-line no-console
+        console.warn(msg);
+      } else if (initialReq.status === 403) {
+        // eslint-disable-next-line no-console
+        console.log(msg);
+      } else {
+        // eslint-disable-next-line no-console
+        console.error(msg);
+      }
       const err = new Error(`unable to get resource - status: ${initialReq.status}`);
       err.status = initialReq.status;
       throw err;

--- a/test/edge.test.js
+++ b/test/edge.test.js
@@ -1439,6 +1439,63 @@ describe('Worker test suite', () => {
     }
   });
 
+  async function testInitSessionLogLevel(status, expectedLevel) {
+    const savedNWSP = DocRoom.newWebSocketPair;
+    const savedBS = persistence.bindState;
+    try {
+      persistence.bindState = async () => {
+        const err = new Error(`unable to get resource - status: ${status}`);
+        err.status = status;
+        throw err;
+      };
+      const wsp1 = { serializeAttachment() {}, close() {}, auth: undefined };
+      DocRoom.newWebSocketPair = () => [{}, wsp1];
+
+      const dr = new DocRoom(makeCtx(null), { daadmin: { mark: 'da' } });
+      const headers = new Headers({
+        Upgrade: 'websocket',
+        Authorization: 'au123',
+        'X-collab-room': 'http://foo.bar/sendto/doc.html',
+      });
+      const req = { headers, url: 'http://localhost:4711/' };
+
+      const logged = [];
+      const origWarn = console.warn;
+      const origLog = console.log;
+      const origError = console.error;
+      console.warn = (...a) => logged.push(['warn', ...a]);
+      console.log = (...a) => logged.push(['log', ...a]);
+      console.error = (...a) => logged.push(['error', ...a]);
+      try {
+        await dr.fetch(req, {}, 306);
+        await sleep(20);
+      } finally {
+        console.warn = origWarn;
+        console.log = origLog;
+        console.error = origError;
+      }
+
+      const entry = logged.find(([, msg]) => typeof msg === 'string' && msg.includes('Error during session setup'));
+      assert(entry, `Expected '[docroom] Error during session setup' log entry for status ${status}`);
+      assert.equal(entry[0], expectedLevel, `Expected '${expectedLevel}' for status ${status}, got '${entry[0]}'`);
+    } finally {
+      DocRoom.newWebSocketPair = savedNWSP;
+      persistence.bindState = savedBS;
+    }
+  }
+
+  it('Test DocRoom initSession logs console.warn on 401 (auth outcome is operational noise)', async () => {
+    await testInitSessionLogLevel(401, 'warn');
+  });
+
+  it('Test DocRoom initSession logs console.log on 403 (ACL denial is operational noise)', async () => {
+    await testInitSessionLogLevel(403, 'log');
+  });
+
+  it('Test DocRoom initSession logs console.error on other failures', async () => {
+    await testInitSessionLogLevel(500, 'error');
+  });
+
   it('Test DocRoom webSocketMessage works with an attachment that has no isHelix field', async () => {
     const savedBS = persistence.bindState;
     try {

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -241,6 +241,44 @@ describe('Collab Test Suite', () => {
     }
   });
 
+  async function testGetLogLevel(status, statusText, expectedLevel) {
+    const daadmin = {
+      fetch: async () => ({ ok: false, status, statusText }),
+    };
+    const logged = [];
+    const origWarn = console.warn;
+    const origLog = console.log;
+    const origError = console.error;
+    console.warn = (...a) => logged.push(['warn', ...a]);
+    console.log = (...a) => logged.push(['log', ...a]);
+    console.error = (...a) => logged.push(['error', ...a]);
+    try {
+      await persistence.get('foo', 'auth', daadmin);
+      assert.fail('Should have thrown');
+    } catch (_) {
+      // expected
+    } finally {
+      console.warn = origWarn;
+      console.log = origLog;
+      console.error = origError;
+    }
+    const entry = logged.find(([, msg]) => typeof msg === 'string' && msg.includes('Unable to get resource from da-admin'));
+    assert(entry, `Expected a log entry for status ${status}`);
+    assert.equal(entry[0], expectedLevel, `Expected '${expectedLevel}' for status ${status}, got '${entry[0]}'`);
+  }
+
+  it('Test persistence get logs console.warn on 401', async () => {
+    await testGetLogLevel(401, 'Unauthorized', 'warn');
+  });
+
+  it('Test persistence get logs console.log on 403 (ACL denial is operational noise)', async () => {
+    await testGetLogLevel(403, 'Forbidden', 'log');
+  });
+
+  it('Test persistence get logs console.error on other failures', async () => {
+    await testGetLogLevel(500, 'Internal Server Error', 'error');
+  });
+
   it('Test persistence put ok', async () => {
     const daadmin = {};
     daadmin.fetch = async (url, opts) => {


### PR DESCRIPTION
## Summary

GET-side 401/403 are auth/ACL outcomes the worker cannot bypass — they are operational noise, not service errors. PUT-side already demotes these via `persistence.update` (#135); GET-side and `initSession` should match so the error stream stays a real-signal channel.

- `persistence.get`: 401 → `console.warn`, 403 → `console.log`, other → `console.error`
- `DocRoom.initSession`: same routing on the caught error (status carried by the thrown `Error`, so we don't re-parse strings)
- 6 black-box tests asserting the chosen log level per status

## Why now

Daily Coralogix review saw ≥96/24h `[docroom] Unable to get resource from da-admin: 403 - Forbidden` on `aemcoder/sendto/*` (two UUID-named docs, ~2/hour each). Investigation confirmed:

- da-collab does **not** retry on its own; the cycle is driven by the client/feature owner.
- The PUT path was already demoted to `console.log` on 403; the GET path was inconsistent and was the only source of the daily error-stream spike.
- Worker logging should reflect a routine ACL outcome.

The underlying retry behavior on the `sendto` client is a separate concern, tracked in the source ticket.

## Test plan

- [x] `npx mocha test/shareddoc.test.js --grep "persistence get logs"` — 3 new tests pass
- [x] `npx mocha test/edge.test.js --grep "initSession logs"` — 3 new tests pass
- [x] `npx mocha --exit test/` — full suite 160 passing
- [x] `npx eslint src/ test/` clean on touched files

Co-authored-by: Paperclip <noreply@paperclip.ing>
