### PR TITLE
fix(docroom): await all closeConns in invalidateFromAdmin to close race window

### DIFF
--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -903,9 +903,11 @@ export const invalidateFromAdmin = async (docName) => {
   console.log('[worker] Invalidate from Admin received', docName);
   const ydoc = docs.get(docName);
   if (ydoc) {
-    // As we are closing all connections, the ydoc will be removed from the docs map
-    ydoc.conns.forEach((_, c) => closeConn(ydoc, c));
-
+    // Await all closeConn calls so that flushSave + docs.delete complete before
+    // this function returns. Without this, an editor that reconnects during the
+    // flushSave window finds the stale ydoc still in `docs` and reuses it
+    // instead of creating a fresh one that loads the new da-admin content.
+    await Promise.all(Array.from(ydoc.conns.keys()).map((c) => closeConn(ydoc, c)));
     return true;
   } else {
     // eslint-disable-next-line no-console

--- a/test/invalidate-race.test.js
+++ b/test/invalidate-race.test.js
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Regression tests for the invalidateFromAdmin race condition.
+ *
+ * Root cause (fixed): invalidateFromAdmin called closeConn via a non-awaited
+ * forEach, so the function resolved before flushSave + docs.delete completed.
+ * An editor reconnecting during that window grabbed the stale ydoc from `docs`
+ * instead of creating a fresh one that fetches the updated da-admin content.
+ *
+ * Fix: await Promise.all over all closeConn calls so docs.delete is guaranteed
+ * to complete before invalidateFromAdmin returns.
+ */
+
+import assert from 'node:assert';
+import { invalidateFromAdmin, setYDoc, WSSharedDoc } from '../src/shareddoc.js';
+
+const wait = (ms) => new Promise((r) => {
+  setTimeout(r, ms);
+});
+
+describe('invalidateFromAdmin race condition', () => {
+  it('1 editor: docs entry removed and flushSave complete before invalidateFromAdmin returns', async () => {
+    const docName = 'https://admin.da.live/source/org/repo/one-editor.html';
+
+    const ydoc = new WSSharedDoc(docName);
+    const docs = setYDoc(docName, ydoc);
+
+    const conn1 = { close() {} };
+    ydoc.conns.set(conn1, new Set());
+
+    let flushDone = false;
+    ydoc.flushSave = async () => {
+      await wait(50);
+      flushDone = true;
+    };
+
+    await invalidateFromAdmin(docName);
+
+    assert.equal(flushDone, true, 'flushSave must complete before invalidateFromAdmin returns');
+    assert.equal(docs.get(docName), undefined, 'doc must be removed from docs before invalidateFromAdmin returns');
+  });
+
+  it('2 editors: no stale ydoc visible after invalidateFromAdmin — reconnect creates fresh ydoc', async () => {
+    const docName = 'https://admin.da.live/source/org/repo/two-editors.html';
+
+    const ydoc = new WSSharedDoc(docName);
+    const docs = setYDoc(docName, ydoc);
+
+    const conn1 = { close() {} };
+    const conn2 = { close() {} };
+    ydoc.conns.set(conn1, new Set());
+    ydoc.conns.set(conn2, new Set());
+
+    let flushDone = false;
+    ydoc.flushSave = async () => {
+      await wait(50);
+      flushDone = true;
+    };
+
+    await invalidateFromAdmin(docName);
+
+    // After await: flushSave done, doc gone — reconnecting editor gets undefined
+    // from docs.get() and creates a fresh ydoc that fetches new content from da-admin
+    assert.equal(flushDone, true, 'flushSave must complete before invalidateFromAdmin returns');
+    assert.equal(docs.get(docName), undefined, 'stale ydoc must not be in docs — reconnect loads fresh content');
+  });
+
+  it('2 editors: reconnect immediately after invalidateFromAdmin finds no stale ydoc', async () => {
+    const docName = 'https://admin.da.live/source/org/repo/immediate-reconnect.html';
+
+    const ydoc = new WSSharedDoc(docName);
+    const docs = setYDoc(docName, ydoc);
+
+    const conn1 = { close() {} };
+    const conn2 = { close() {} };
+    ydoc.conns.set(conn1, new Set());
+    ydoc.conns.set(conn2, new Set());
+
+    ydoc.flushSave = async () => {
+      await wait(50);
+    };
+
+    const invalidatePromise = invalidateFromAdmin(docName);
+
+    // Simulate immediate reconnect attempt (before invalidation settled)
+    // With the fix, this microtask sees no doc because invalidateFromAdmin
+    // awaits all closeConns before returning — so the race window is closed.
+    // We can't truly race in a test, but we can verify the promise contract:
+    // by the time invalidateFromAdmin resolves, the map is already clean.
+    await invalidatePromise;
+
+    const docOnReconnect = docs.get(docName);
+    assert.equal(docOnReconnect, undefined, 'docs is clean after await — reconnect gets fresh ydoc');
+  });
+});


### PR DESCRIPTION
## Summary

- `invalidateFromAdmin` used a non-awaited `forEach` to close connections, so the function resolved before `flushSave` + `docs.delete` completed
- With 2+ editors open, an editor reconnecting during the `flushSave` window grabbed the stale ydoc from `docs` instead of creating a fresh one — the new da-admin content (e.g. written by an agent) was never loaded into the editor
- Fix: `await Promise.all(...)` over all `closeConn` calls so `docs` is clean before `invalidateFromAdmin` returns

## Root cause detail

When an agent PUTs a new document to da-admin, da-admin triggers `syncAdmin` on da-collab. `invalidateFromAdmin` closes all WS connections and the DO removes the ydoc from its in-memory `docs` map. But with 2+ editors, the non-awaited `forEach` meant the function returned while `flushSave` (async persistence flush) was still in-flight — `docs.delete` had not been called yet. Both editors reconnected immediately, found the stale ydoc still in `docs`, and reused it. No fresh `bindState` ran, so the new da-admin content was never fetched.

## Test plan

- New test file `test/invalidate-race.test.js` with 3 cases covering 1-editor, 2-editor, and immediate-reconnect scenarios
- All 174 existing tests pass
- Manually reproduced with the `da-roundtrip.js` script: open 2 editors on same doc → run script with `-x` → changes now appear in both editors after invalidation

🤖 Generated with [Claude Code](https://claude.com/claude-code)