### PR TITLE
fix: register conn defensively in handleWebSocketMessage to close awareness race

### DIFF
--- a/src/shareddoc.js
+++ b/src/shareddoc.js
@@ -991,6 +991,13 @@ export const handleWebSocketMessage = async (conn, docName, env, storage, messag
     // DO was hibernated; re-establish Yjs state without re-registering event listeners
     await setupWSConnection(conn, docName, env, storage, ctx, true);
     doc = docs.get(docName);
+  } else if (!doc.conns.has(conn)) {
+    // The doc was already cached (another connection got there first), so the setup
+    // path above was skipped. Register conn defensively — without this, a client that
+    // wins the race against ctx.waitUntil(initSession(...)) can have its awareness
+    // update processed before initSession's own doc.conns registration runs, leaving
+    // its clientID attributed to no conn and leaking it forever on close.
+    doc.conns.set(conn, new Set());
   }
   if (doc) {
     await messageListener(conn, doc, new Uint8Array(message));

--- a/test/shareddoc.test.js
+++ b/test/shareddoc.test.js
@@ -11,6 +11,7 @@
  */
 import * as Y from 'yjs';
 import * as syncProtocol from 'y-protocols/sync.js';
+import * as awarenessProtocol from 'y-protocols/awareness.js';
 import * as encoding from 'lib0/encoding.js';
 import * as decoding from 'lib0/decoding.js';
 import assert from 'node:assert';
@@ -20,7 +21,7 @@ import {
   aem2doc, doc2aem, doc2json, EMPTY_DOC,
 } from '@adobe/da-parser';
 import {
-  closeConn, getBackend, getYDoc, isHelixDoc,
+  closeConn, getBackend, getYDoc, handleWebSocketMessage, isHelixDoc,
   invalidateFromAdmin, isExpectedPlatformEvent, messageFlushRequest,
   messageFlushResponse, messageListener, persistence,
   readState, safePutLastsync, setupWSConnection, setYDoc,
@@ -1740,6 +1741,52 @@ describe('Collab Test Suite', () => {
     } finally {
       persistence.bindState = savedBS;
     }
+  });
+
+  it('handleWebSocketMessage registers conn in doc.conns even when doc already exists', async () => {
+    // Reproduces the reload-duplicate-awareness bug: initSession's ctx.waitUntil(...)
+    // registers the conn into doc.conns asynchronously and isn't awaited before the
+    // 101 response returns. If the doc is already cached (another tab connected) and
+    // the client's first awareness message wins that race, handleWebSocketMessage used
+    // to skip registration entirely (it only ran setupWSConnection when `doc` was
+    // missing), so the new clientID got broadcast/stored but never attributed to any
+    // conn — leaving closeConn with an empty controlledIds set and leaking the
+    // awareness entry forever.
+    const docName = 'http://www.acme.org/racedoc.html';
+    const ydoc = new WSSharedDoc(docName);
+    setYDoc(docName, ydoc);
+
+    // Simulate an already-connected peer (the other open tab).
+    const existingConn = { readyState: 1, send: () => {}, close: () => {} }; // wsReadyStateOpen
+    ydoc.conns.set(existingConn, new Set());
+
+    // Build a real awareness update, as a newly-connecting tab would send it.
+    const clientDoc = new Y.Doc();
+    const clientAwareness = new awarenessProtocol.Awareness(clientDoc);
+    clientAwareness.setLocalState({ user: { id: 'u1', name: 'User One' } });
+    const update = awarenessProtocol.encodeAwarenessUpdate(clientAwareness, [clientDoc.clientID]);
+    const encoder = encoding.createEncoder();
+    encoding.writeVarUint(encoder, 1); // messageAwareness
+    encoding.writeVarUint8Array(encoder, update);
+    const message = encoding.toUint8Array(encoder);
+
+    // newConn's own doc.conns registration has NOT happened yet — the race being tested.
+    const newConn = { readyState: 1, send: () => {}, close: () => {} }; // wsReadyStateOpen
+    await handleWebSocketMessage(newConn, docName, {}, {}, message, {});
+
+    assert(ydoc.conns.has(newConn), 'conn should be registered even though doc already existed');
+    assert.deepStrictEqual(Array.from(ydoc.conns.get(newConn)), [clientDoc.clientID]);
+    assert(ydoc.awareness.getStates().has(clientDoc.clientID));
+
+    // The new conn closes (e.g. tab reloads again) — its awareness state must go with it.
+    await closeConn(ydoc, newConn);
+    assert(
+      !ydoc.awareness.getStates().has(clientDoc.clientID),
+      'awareness state must be cleaned up on close, not leaked',
+    );
+
+    clientAwareness.destroy();
+    clientDoc.destroy();
   });
 
   it('Test WSSharedDoc', () => {


### PR DESCRIPTION
## Summary
- Two open editors on the same doc could accumulate duplicate "AC" presence indicators on repeated reloads.
- Root cause: `initSession`'s `ctx.waitUntil(...)` registers a new socket into `doc.conns` asynchronously and isn't awaited before the WS upgrade response returns. If the doc is already cached (another tab connected) and the client's first awareness message wins that race, its clientID gets broadcast/stored but is never attributed to any conn — so `closeConn` later finds nothing to remove, leaking the awareness entry until each peer's own 30s outdated-timeout self-heals it.
- Fix: `handleWebSocketMessage` now registers the conn into `doc.conns` defensively whenever it's missing, regardless of which path (cold-start setup vs. already-cached doc) got there first.

## Test plan
- [x] Added a regression test reproducing the exact race (fails on pre-fix code, passes post-fix)
- [x] Full suite: 175/175 passing, coverage thresholds met
- [x] `npm run lint` clean
- [x] Manually reproduced locally (wrangler dev) with two tabs + repeated reloads, confirmed no more stuck ghost indicators